### PR TITLE
fix issue 81 card showing feature disabled

### DIFF
--- a/custom_components/ramses_extras/framework/setup/cards.py
+++ b/custom_components/ramses_extras/framework/setup/cards.py
@@ -304,9 +304,6 @@ async def register_cards(hass: HomeAssistant) -> None:
 
         _LOGGER.info("Feature-centric CardRegistry registration complete")
 
-        # Signal frontend to hard refresh the card
-        hass.bus.async_fire("ramses_extras_card_refresh")
-
     except Exception as e:
         _LOGGER.error("CardRegistry registration failed: %s", e)
         _LOGGER.warning("Continuing integration startup without card registration")
@@ -433,6 +430,11 @@ async def setup_card_files_and_config(hass: HomeAssistant, entry: ConfigEntry) -
         await copy_all_card_files(hass, card_features)
 
         await expose_feature_config_to_frontend(hass, entry)
+
+        # Signal frontend to reload only after all card files and features.js
+        # are fully written - prevents the browser from fetching a missing or
+        # stale ramses-extras-features.js and showing "Feature Disabled".
+        hass.bus.async_fire("ramses_extras_card_refresh")
 
         _LOGGER.info("Card files and configuration setup complete")
 

--- a/custom_components/ramses_extras/manifest.json
+++ b/custom_components/ramses_extras/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wimpie70/ramses_extras/issues",
   "requirements": [],
-  "version": "0.19.5"
+  "version": "0.19.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ramses_extras"
-version = "0.19.5"
+version = "0.19.6"
 description = "Extra features for Ramses CC integration"
 authors = ["Willem (wimpie70)"]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="ramses_extras",
-    version="0.19.5",
+    version="0.19.6",
     packages=[
         "custom_components.ramses_extras",
         "custom_components.ramses_extras.framework",


### PR DESCRIPTION
Found it. This is a clear race condition:

In setup_card_files_and_config (@/home/willem/dev/ramses_extras/custom_components/ramses_extras/framework/setup/cards.py:428-435):

python
await register_cards(hass)           # ← fires ramses_extras_card_refresh → browser reloads NOW
await cleanup_old_card_deployments(...)
await copy_all_card_files(...)
await expose_feature_config_to_frontend(hass, entry)  # ← writes features.js TOO LATE
The browser gets the reload signal before ramses-extras-features.js is written. It fetches the features file immediately, gets either nothing (new install/version upgrade after cleanup) or the stale previous file. Result: window.ramsesExtras.features is wrong or absent → "Feature Disabled."

For device_simulator it's even worse: _enforce_simulator_isolation then reloads ramses_cc, which may trigger a second pipeline run — another race, another bad reload.

Fix: move the card_refresh fire to after all files are written.

One-line move, but it closes the race. Before this fix, the order was:

register_cards → fires reload signal → browser fetches missing/stale files
cleanup old files
copy new card files
write ramses-extras-features.js


After:

register_cards (just HA resource registration, no signal)
cleanup + copy files
write ramses-extras-features.js
fire reload signal → browser fetches complete, up-to-date files

This should fix both issue #81  "Feature Disabled" on restart and also the device_simulator stale-card experience. The _enforce_simulator_isolation ramses_cc reload still happens after this, but by then the browser already has the correct card files loaded.