### PR TITLE
adapt to latest changes on _rf  #641 DTO phase 2

### DIFF
--- a/custom_components/ramses_extras/features/device_simulator/__init__.py
+++ b/custom_components/ramses_extras/features/device_simulator/__init__.py
@@ -46,8 +46,13 @@ _SZ_ORIGINAL_SCHEMA = "original_schema"
 _SZ_ORIGINAL_KNOWN_LIST = "original_known_list"
 _SZ_ORIGINAL_ENFORCE_KNOWN_LIST = "original_enforce_known_list"
 _SZ_ORIGINAL_ENABLE_EAVESDROP = "original_enable_eavesdrop"
+_SZ_ORIGINAL_MQTT_TOPIC = "original_mqtt_topic"
+_SZ_ORIGINAL_MQTT_HGI_ID = "original_mqtt_hgi_id"
 _SZ_STATE_SAVED = "state_saved"
 _DEFAULT_GATEWAY_TOPIC_NS = "RAMSES/GATEWAY"
+_SZ_MQTT_USE_HA = "mqtt_use_ha"
+_SZ_MQTT_TOPIC = "mqtt_topic"
+_SZ_MQTT_HGI_ID = "mqtt_hgi_id"
 
 
 def _make_isolation_store(hass: HomeAssistant) -> HaStore:
@@ -117,6 +122,8 @@ async def _remember_original_ramses_cc_state(
     known_list: Any,
     enforce_known_list: Any,
     enable_eavesdrop: Any,
+    mqtt_topic: Any = None,
+    mqtt_hgi_id: Any = None,
 ) -> None:
     """Save original ramses_cc options before simulator isolation overwrites them.
 
@@ -140,12 +147,16 @@ async def _remember_original_ramses_cc_state(
     )
     state[_SZ_ORIGINAL_ENFORCE_KNOWN_LIST] = enforce_known_list
     state[_SZ_ORIGINAL_ENABLE_EAVESDROP] = enable_eavesdrop
+    state[_SZ_ORIGINAL_MQTT_TOPIC] = mqtt_topic
+    state[_SZ_ORIGINAL_MQTT_HGI_ID] = mqtt_hgi_id
     state[_SZ_STATE_SAVED] = True
     await store.async_save(state)
     _LOGGER.info(
         "Saved original ramses_cc state for simulator cleanup "
-        "(port=%s schema_keys=%s known_list_count=%s enforce=%s eavesdrop=%s)",
+        "(port=%s topic=%s hgi=%s schema_keys=%s known_list_count=%s enforce=%s eavesdrop=%s)",  # noqa: E501
         port_name,
+        mqtt_topic,
+        mqtt_hgi_id,
         list(schema.keys()) if isinstance(schema, dict) else None,
         len(known_list) if isinstance(known_list, dict) else None,
         enforce_known_list,
@@ -179,15 +190,28 @@ async def async_restore_ramses_cc_gateway_topic(hass: HomeAssistant) -> bool:
     cc_options = dict(cc_entry.options) if cc_entry.options else {}
     serial_port = dict(cc_options.get("serial_port", {}))
     current_port = serial_port.get("port_name")
+    current_mqtt_topic = cc_options.get(_SZ_MQTT_TOPIC)
+    current_mqtt_hgi_id = cc_options.get(_SZ_MQTT_HGI_ID)
 
     store, state = await _load_isolation_state(hass)
     stored_port = state.get(_SZ_ORIGINAL_PORT)
+    stored_mqtt_topic = state.get(_SZ_ORIGINAL_MQTT_TOPIC)
+    stored_mqtt_hgi_id = state.get(_SZ_ORIGINAL_MQTT_HGI_ID)
     state_saved = state.get(_SZ_STATE_SAVED, False)
     isolation_active = isinstance(current_port, str) and (
         SIMULATOR_TOPIC_NS in current_port or SIMULATOR_HGI_ID in current_port
     )
+    isolation_active = isolation_active or (
+        current_mqtt_topic == SIMULATOR_TOPIC_NS
+        and current_mqtt_hgi_id == SIMULATOR_HGI_ID
+    )
 
-    if not stored_port and not isolation_active:
+    if (
+        not stored_port
+        and stored_mqtt_topic is None
+        and stored_mqtt_hgi_id is None
+        and not isolation_active
+    ):
         _LOGGER.debug("Simulator isolation already cleared - nothing to restore")
         if state:
             await store.async_save({})
@@ -196,12 +220,11 @@ async def async_restore_ramses_cc_gateway_topic(hass: HomeAssistant) -> bool:
     # Resolve target port (stored or fallback)
     target_port = stored_port
     used_fallback = False
-    if not target_port:
-        if not isinstance(current_port, str):
-            _LOGGER.warning(
-                "Simulator isolation fallback failed: current ramses_cc port missing",
-            )
-            return False
+    if (
+        not target_port
+        and isinstance(current_port, str)
+        and current_port.startswith("mqtt://")
+    ):
         try:
             target_port = _build_default_gateway_port(current_port)
             used_fallback = True
@@ -216,9 +239,16 @@ async def async_restore_ramses_cc_gateway_topic(hass: HomeAssistant) -> bool:
     # Build restored options
     changed = False
 
-    if target_port != current_port:
+    if target_port and target_port != current_port:
         serial_port["port_name"] = target_port
         cc_options["serial_port"] = serial_port
+        changed = True
+
+    if stored_mqtt_topic is not None and stored_mqtt_topic != current_mqtt_topic:
+        cc_options[_SZ_MQTT_TOPIC] = stored_mqtt_topic
+        changed = True
+    if stored_mqtt_hgi_id is not None and stored_mqtt_hgi_id != current_mqtt_hgi_id:
+        cc_options[_SZ_MQTT_HGI_ID] = stored_mqtt_hgi_id
         changed = True
 
     if state_saved:
@@ -267,7 +297,12 @@ async def async_restore_ramses_cc_gateway_topic(hass: HomeAssistant) -> bool:
     # Clear saved state so a subsequent sim-enable will re-capture
     await store.async_save({})
 
-    _LOGGER.info("Restored ramses_cc MQTT serial_port to %s", target_port)
+    _LOGGER.info(
+        "Restored ramses_cc simulator transport settings (port=%s topic=%s hgi=%s)",
+        target_port or current_port,
+        cc_options.get(_SZ_MQTT_TOPIC),
+        cc_options.get(_SZ_MQTT_HGI_ID),
+    )
     if used_fallback:
         _LOGGER.warning(
             "Simulator restore used fallback topic %s - please verify gateway ID",
@@ -343,6 +378,10 @@ async def _enforce_simulator_isolation(hass: HomeAssistant) -> bool:
     cc_options = dict(cc_entry.options) if cc_entry.options else {}
     serial_port = dict(cc_options.get("serial_port", {}))
     port_name = serial_port.get("port_name", "")
+    mqtt_topic = cc_options.get(_SZ_MQTT_TOPIC)
+    mqtt_hgi_id = cc_options.get(_SZ_MQTT_HGI_ID)
+    mqtt_use_ha = bool(cc_options.get(_SZ_MQTT_USE_HA))
+    using_mqtt_ha = port_name == "mqtt_ha" or mqtt_use_ha
 
     # Capture current ramses_cc state before any modification so we can
     # restore the user's real-device configuration on disable/remove.
@@ -363,12 +402,16 @@ async def _enforce_simulator_isolation(hass: HomeAssistant) -> bool:
     _LOGGER.debug("Checking ramses_cc config: port_name=%s", port_name)
 
     # Check if using MQTT (device_simulator only makes sense with MQTT)
-    if not port_name.startswith("mqtt://"):
+    if not (using_mqtt_ha or port_name.startswith("mqtt://")):
         _LOGGER.info("ramses_cc not using MQTT - simulator isolation not applicable")
         return True
 
     # Check if already using simulator isolation
-    if SIMULATOR_HGI_ID in port_name and SIMULATOR_TOPIC_NS in port_name:
+    if using_mqtt_ha:
+        if mqtt_topic == SIMULATOR_TOPIC_NS and mqtt_hgi_id == SIMULATOR_HGI_ID:
+            _LOGGER.info("ramses_cc already configured for simulator isolation")
+            return True
+    elif SIMULATOR_HGI_ID in port_name and SIMULATOR_TOPIC_NS in port_name:
         _LOGGER.info("ramses_cc already configured for simulator isolation")
         return True
 
@@ -389,29 +432,48 @@ async def _enforce_simulator_isolation(hass: HomeAssistant) -> bool:
             current_known_list,
             current_enforce,
             current_eavesdrop,
+            mqtt_topic,
+            mqtt_hgi_id,
         )
 
-        auth, host_port, _ = _parse_mqtt_port(port_name)
+        changed = False
+        if using_mqtt_ha:
+            if cc_options.get(_SZ_MQTT_TOPIC) != SIMULATOR_TOPIC_NS:
+                cc_options[_SZ_MQTT_TOPIC] = SIMULATOR_TOPIC_NS
+                changed = True
+            if cc_options.get(_SZ_MQTT_HGI_ID) != SIMULATOR_HGI_ID:
+                cc_options[_SZ_MQTT_HGI_ID] = SIMULATOR_HGI_ID
+                changed = True
+            _LOGGER.info(
+                "Updating ramses_cc mqtt_ha transport to topic='%s' hgi='%s'",
+                SIMULATOR_TOPIC_NS,
+                SIMULATOR_HGI_ID,
+            )
+        else:
+            auth, host_port, _ = _parse_mqtt_port(port_name)
 
-        # ramses_rf requires RAMSES/GATEWAY* prefix, SIMULATOR_TOPIC_NS is valid
-        new_port_name = _compose_mqtt_port(
-            auth,
-            host_port,
-            SIMULATOR_TOPIC_NS,
-            SIMULATOR_HGI_ID,
-        )
+            # ramses_rf requires RAMSES/GATEWAY* prefix, SIMULATOR_TOPIC_NS is valid
+            new_port_name = _compose_mqtt_port(
+                auth,
+                host_port,
+                SIMULATOR_TOPIC_NS,
+                SIMULATOR_HGI_ID,
+            )
 
-        _LOGGER.info(
-            "Updating ramses_cc serial_port from '%s' to '%s'", port_name, new_port_name
-        )
-        _LOGGER.info(
-            "Simulator will use HGI %s - completely isolated from production HGI",
-            SIMULATOR_HGI_ID,
-        )
+            _LOGGER.info(
+                "Updating ramses_cc serial_port from '%s' to '%s'",
+                port_name,
+                new_port_name,
+            )
+            serial_port["port_name"] = new_port_name
+            cc_options["serial_port"] = serial_port
+            changed = new_port_name != port_name
 
-        # Update config entry
-        serial_port["port_name"] = new_port_name
-        cc_options["serial_port"] = serial_port
+        if not changed:
+            _LOGGER.info(
+                "Simulator isolation already active, no ramses_cc reload needed"
+            )
+            return True
 
         hass.config_entries.async_update_entry(cc_entry, options=cc_options)
 

--- a/custom_components/ramses_extras/features/device_simulator/message_log.py
+++ b/custom_components/ramses_extras/features/device_simulator/message_log.py
@@ -76,9 +76,16 @@ def _decode_payload(
     import logging
 
     try:
-        from ramses_tx.message import Message
+        from ramses_rf.message import Message
+    except (ModuleNotFoundError, ImportError):
+        try:
+            from ramses_tx.message import Message
+        except (ModuleNotFoundError, ImportError):
+            return None
+
+    try:
         from ramses_tx.packet import Packet
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):
         return None
 
     via = (

--- a/custom_components/ramses_extras/features/device_simulator/scenarios/discovery_test.py
+++ b/custom_components/ramses_extras/features/device_simulator/scenarios/discovery_test.py
@@ -7,11 +7,14 @@ from ..const import SCENARIO_AUTO_ANSWER, SCENARIO_DISCOVERY_TEST, VERB_I
 from ..system_config import SIM_DEVICE_ID
 from .base import ScenarioContext, ScenarioDefinition, ScenarioResult
 
+DEFAULT_PAYLOAD = "0000000000000000"
+
 
 async def run(context: ScenarioContext, params: dict[str, Any]) -> ScenarioResult:
     slug = str(params.get("slug", "FAN")) or "FAN"
     slug = slug.upper()
-    device_id = params.get("device_id") or SIM_DEVICE_ID.get(slug)
+
+    device_id = _resolve_device_id(context, slug, params.get("device_id"))
     if not device_id:
         return ScenarioResult(
             scenario_id=SCENARIO_DISCOVERY_TEST,
@@ -19,17 +22,7 @@ async def run(context: ScenarioContext, params: dict[str, Any]) -> ScenarioResul
             errors=[f"No device_id available for slug '{slug}'"],
         )
 
-    fingerprint = params.get("fingerprint")
-    payload = params.get("payload")
-    if not payload:
-        if fingerprint:
-            payload = (
-                context.device_db.get_fingerprint_payload(fingerprint) or fingerprint
-            )
-        else:
-            payload = fingerprint or "0000000000000000"
-
-    payload = str(payload).upper()
+    payload = _resolve_payload(context, slug, device_id, params)
     count = max(1, int(params.get("count", 3)))
     interval = float(params.get("interval", 1.0))
     include_burst = bool(params.get("include_startup_burst", True))
@@ -52,9 +45,11 @@ async def run(context: ScenarioContext, params: dict[str, Any]) -> ScenarioResul
         SCENARIO_DISCOVERY_TEST,
         {
             "device_id": device_id,
+            "slug": slug,
             "count": count,
             "interval": interval,
             "payload": payload,
+            "include_startup_burst": include_burst,
         },
     )
 
@@ -64,6 +59,8 @@ async def run(context: ScenarioContext, params: dict[str, Any]) -> ScenarioResul
         details={
             "message": f"Emitting {count} discovery frames from {device_id}",
             "device_id": device_id,
+            "slug": slug,
+            "payload": payload,
             "count": count,
             "interval": interval,
         },
@@ -95,6 +92,51 @@ async def _emit_discovery_frames(
         raise
     finally:
         context.clear_running(SCENARIO_DISCOVERY_TEST)
+
+
+def _resolve_device_id(
+    context: ScenarioContext, slug: str, explicit_id: str | None
+) -> str | None:
+    if explicit_id:
+        return str(explicit_id).upper()
+
+    active = context.active_devices_by_slug(slug)
+    if active:
+        return active[0].device_id
+
+    return SIM_DEVICE_ID.get(slug)
+
+
+def _resolve_payload(
+    context: ScenarioContext,
+    slug: str,
+    device_id: str,
+    params: dict[str, Any],
+) -> str:
+    payload = params.get("payload")
+    if payload:
+        return str(payload).replace(" ", "").upper()
+
+    fingerprint = params.get("fingerprint")
+    if fingerprint:
+        resolved = context.device_db.get_fingerprint_payload(str(fingerprint).upper())
+        if resolved:
+            return resolved.upper()
+        return str(fingerprint).upper()
+
+    active_device = context.get_active_device(device_id)
+    if active_device:
+        response = context.device_db.find_response(
+            active_device.slug, "10E0", active_device.variant_id
+        )
+        if response and response.payloads:
+            return response.payloads[0].upper()
+
+    entry = context.device_db.find_response(slug, "10E0", None)
+    if entry and entry.payloads:
+        return entry.payloads[0].upper()
+
+    return DEFAULT_PAYLOAD
 
 
 SCENARIO_DEFINITION = ScenarioDefinition(

--- a/custom_components/ramses_extras/features/ramses_debugger/log_backend.py
+++ b/custom_components/ramses_extras/features/ramses_debugger/log_backend.py
@@ -98,23 +98,47 @@ def get_configured_packet_log_path(hass: HomeAssistant) -> Path | None:
     if isinstance(raw_override, str) and raw_override.strip():
         return _resolve_packet_log_base_path(raw_override, "packet_log")
 
+    def _default_packet_log_candidates(prefix: str | None = None) -> list[Path]:
+        chosen_prefix = prefix if isinstance(prefix, str) and prefix else "packet_log"
+        return [
+            Path(hass.config.path(f"{chosen_prefix}.log")),
+            Path(hass.config.path("ramses_rf_logs", f"{chosen_prefix}.log")),
+        ]
+
     try:
         entries = hass.config_entries.async_entries("ramses_cc")
         for cc_entry in entries:
             cc_options = getattr(cc_entry, "options", {})
+            cc_data = getattr(cc_entry, "data", {})
+            merged_config: dict[str, Any] = {}
+            if isinstance(cc_data, dict):
+                merged_config.update(cc_data)
+            if isinstance(cc_options, dict):
+                merged_config.update(cc_options)
 
             # v2 location: packet_log.packet_log_path + packet_log_prefix
-            packet_log = cc_options.get("packet_log")
+            packet_log = merged_config.get("packet_log")
             if isinstance(packet_log, dict):
+                packet_log_path = packet_log.get("packet_log_path") or packet_log.get(
+                    "path"
+                )
+                packet_log_prefix = packet_log.get(
+                    "packet_log_prefix"
+                ) or packet_log.get("prefix")
                 path = _resolve_packet_log_base_path(
-                    packet_log.get("packet_log_path") or packet_log.get("file_name"),
-                    packet_log.get("packet_log_prefix"),
+                    packet_log_path or packet_log.get("file_name"),
+                    packet_log_prefix,
                 )
                 if path:
                     return path
 
+                if not packet_log_path:
+                    for candidate in _default_packet_log_candidates(packet_log_prefix):
+                        if candidate.exists():
+                            return candidate
+
             # v1 fallback: ramses_rf.file_name (migration may not have copied it)
-            ramses_rf = cc_options.get("ramses_rf")
+            ramses_rf = merged_config.get("ramses_rf")
             if isinstance(ramses_rf, dict):
                 path = _resolve_packet_log_base_path(
                     ramses_rf.get("file_name"),
@@ -122,6 +146,10 @@ def get_configured_packet_log_path(hass: HomeAssistant) -> Path | None:
                 )
                 if path:
                     return path
+
+            for candidate in _default_packet_log_candidates():
+                if candidate.exists():
+                    return candidate
     except Exception:
         return None
 

--- a/custom_components/ramses_extras/features/ramses_debugger/messages_provider.py
+++ b/custom_components/ramses_extras/features/ramses_debugger/messages_provider.py
@@ -218,9 +218,16 @@ def decode_message_with_ramses_rf(msg: dict[str, Any]) -> dict[str, Any] | None:
     """
 
     try:
-        from ramses_tx.message import Message
+        from ramses_rf.message import Message
+    except (ModuleNotFoundError, ImportError):
+        try:
+            from ramses_tx.message import Message
+        except (ModuleNotFoundError, ImportError):
+            return None
+
+    try:
         from ramses_tx.packet import Packet
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):
         return None
 
     dtm_raw = msg.get("dtm")

--- a/custom_components/ramses_extras/features/ramses_debugger/www/ramses_debugger/ramses-traffic-analyser.js
+++ b/custom_components/ramses_extras/features/ramses_debugger/www/ramses_debugger/ramses-traffic-analyser.js
@@ -56,6 +56,7 @@ class RamsesTrafficAnalyserCard extends RamsesBaseCard {
     this._wsUnsubPromise = null;
     this._wsUnsub = null;
     this._pollInterval = null;
+    this._subscriptionRetryTimer = null;
     this._lastError = null;
 
     this._detailsDialogOpen = false;
@@ -203,6 +204,11 @@ class RamsesTrafficAnalyserCard extends RamsesBaseCard {
 
     this._wsUnsub = null;
     this._wsUnsubPromise = null;
+
+    if (this._subscriptionRetryTimer) {
+      clearTimeout(this._subscriptionRetryTimer);
+      this._subscriptionRetryTimer = null;
+    }
   }
 
   _startUpdates() {
@@ -222,6 +228,9 @@ class RamsesTrafficAnalyserCard extends RamsesBaseCard {
       return;
     }
 
+    // Prime the table with a one-shot snapshot so temporary WS registration races
+    // don't leave the UI empty forever.
+    void this._refreshStatsOnce();
     this._startSubscription();
   }
 
@@ -346,6 +355,18 @@ class RamsesTrafficAnalyserCard extends RamsesBaseCard {
       .catch((error) => {
         this._lastError = error;
         logger.warn('Traffic subscribe failed, consider enabling polling:', error);
+        void this._refreshStatsOnce();
+
+        if (this._subscriptionRetryTimer) {
+          clearTimeout(this._subscriptionRetryTimer);
+        }
+        this._subscriptionRetryTimer = setTimeout(() => {
+          this._subscriptionRetryTimer = null;
+          if (this._trafficSource === 'live' && this._config?.enable_polling !== true) {
+            this._startSubscription();
+          }
+        }, 3000);
+
         this.render();
       });
   }

--- a/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py
+++ b/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
@@ -53,19 +54,38 @@ class RamsesMessageStream:
 
         return _unsub
 
+    def _resolve_add_msg_handler(self, coordinator: Any) -> Callable[..., Any] | None:
+        if coordinator is None:
+            return None
+
+        add_msg_handler = getattr(coordinator, "add_msg_handler", None)
+        if callable(add_msg_handler):
+            return add_msg_handler  # type: ignore[no-any-return]
+
+        client = getattr(coordinator, "client", None)
+        add_msg_handler = getattr(client, "add_msg_handler", None)
+        if callable(add_msg_handler):
+            return add_msg_handler  # type: ignore[no-any-return]
+
+        return None
+
     async def _async_attach_client_listener(self) -> None:
         commands = RamsesCommands(self._hass)
-        coordinator = await commands._get_ramses_cc_coordinator()
-        client = (
-            getattr(coordinator, "client", None) if coordinator is not None else None
-        )
-        add_msg_handler = getattr(client, "add_msg_handler", None)
-        if not callable(add_msg_handler) or self._msg_handler_unsub is not None:
-            return
+        max_attempts = 15
 
-        msg_handler_unsub = add_msg_handler(self._handle_msg)
-        if callable(msg_handler_unsub):
-            self._msg_handler_unsub = msg_handler_unsub
+        for _ in range(max_attempts):
+            if self._msg_handler_unsub is not None:
+                return
+
+            coordinator = await commands._get_ramses_cc_coordinator()
+            add_msg_handler = self._resolve_add_msg_handler(coordinator)
+            if callable(add_msg_handler):
+                msg_handler_unsub = add_msg_handler(self._handle_msg)
+                if callable(msg_handler_unsub):
+                    self._msg_handler_unsub = msg_handler_unsub
+                    return
+
+            await asyncio.sleep(1)
 
     def inject(self, data: dict[str, Any]) -> None:
         """Inject a message directly to all subscribers.

--- a/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py
+++ b/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py
@@ -137,6 +137,15 @@ class RamsesMessageStream:
             "frame": frame.strip(),
         }
 
+    def _extract_msg_addr(self, msg: Any, attr: str, dto_attr: str) -> str | None:
+        value = getattr(getattr(msg, attr, None), "id", None)
+        if isinstance(value, str) and value:
+            return value
+        dto_value = getattr(msg, dto_attr, None)
+        if isinstance(dto_value, str) and dto_value:
+            return dto_value
+        return None
+
     def _handle_ramses_cc_message(self, event: Event[dict[str, Any]]) -> None:
         data = dict(event.data or {})
         data["time_fired"] = event.time_fired.isoformat(timespec="microseconds")
@@ -158,18 +167,28 @@ class RamsesMessageStream:
             else None
         )
         payload = getattr(pkt, "payload", None)
+        if payload is None:
+            payload = getattr(msg, "payload", None)
         data = parsed or {
-            "src": getattr(getattr(msg, "src", None), "id", None),  # type: ignore[dict-item]
-            "dst": getattr(getattr(msg, "dst", None), "id", None),  # type: ignore[dict-item]
+            "src": self._extract_msg_addr(msg, "src", "addr1"),  # type: ignore[dict-item]
+            "dst": self._extract_msg_addr(msg, "dst", "addr2"),  # type: ignore[dict-item]
             "verb": str(getattr(msg, "verb", "")) or None,  # type: ignore[dict-item]
             "code": str(getattr(msg, "code", "")) or None,  # type: ignore[dict-item]
         }
         data["payload"] = str(payload) if payload is not None else None  # type: ignore[assignment]
+
+        if "frame" not in data:
+            frame = self._frame_from_dict(data)
+            if frame:
+                data["frame"] = frame
+
         if isinstance(packet, str) and packet:
             data["packet"] = packet
             data.setdefault("frame", packet)
 
         dtm = getattr(msg, "dtm", None)
+        if dtm is None:
+            dtm = getattr(msg, "timestamp", None)
         if isinstance(dtm, datetime):
             data["dtm"] = dtm.isoformat(timespec="microseconds")
         elif isinstance(dtm, str):

--- a/custom_components/ramses_extras/framework/setup/devices.py
+++ b/custom_components/ramses_extras/framework/setup/devices.py
@@ -83,6 +83,39 @@ _RAMSES_DEVICE_ID_EMBEDDED = re.compile(
 )
 
 
+def _extract_devices_from_candidate(candidate: Any) -> list[Any]:
+    """Extract discovered devices from a coordinator/broker/gateway candidate."""
+    if candidate is None:
+        return []
+
+    # Legacy/new attributes seen across coordinator/gateway revisions.
+    devices = getattr(candidate, "_devices", None)
+    if not devices:
+        devices = getattr(candidate, "devices", None)
+
+    # Some wrappers expose the actual gateway/client under known attributes.
+    if not devices:
+        for nested_attr in ("client", "gateway", "broker"):
+            nested = getattr(candidate, nested_attr, None)
+            if nested is None:
+                continue
+            nested_devices = getattr(nested, "_devices", None)
+            if not nested_devices:
+                nested_devices = getattr(nested, "devices", None)
+            if nested_devices:
+                devices = nested_devices
+                break
+
+    if not devices:
+        return []
+
+    if isinstance(devices, dict):
+        return list(devices.values())
+    if isinstance(devices, (list, set, tuple)):
+        return list(devices)
+    return [devices]
+
+
 async def setup_entity_registry_device_refresh(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -198,11 +231,19 @@ async def async_setup_platforms(hass: HomeAssistant) -> None:
             _LOGGER.debug("Ramses CC is loaded, verifying device discovery...")
 
             device_data = hass.data.setdefault(DOMAIN, {})
-            if "devices" in device_data and "device_discovery_complete" in device_data:
+            cached_devices = device_data.get("devices")
+            cached_complete = "device_discovery_complete" in device_data
+            use_cached = (
+                isinstance(cached_devices, list)
+                and bool(cached_devices)
+                and cached_complete
+            )
+
+            if use_cached:
                 _LOGGER.debug(
                     "Device discovery already completed, using cached results"
                 )
-                devices = device_data["devices"]
+                devices = cached_devices
                 device_ids = [getattr(device, "id", str(device)) for device in devices]
                 _LOGGER.debug("Using cached device IDs: %s", device_ids)
             else:
@@ -263,6 +304,7 @@ async def discover_ramses_devices(hass: HomeAssistant) -> list[Any]:
 
     try:
         broker: Any | None = None
+        devices_list: list[Any] = []
         if "ramses_cc" in hass.data and entry.entry_id in hass.data["ramses_cc"]:
             broker_data = hass.data["ramses_cc"][entry.entry_id]
             if (
@@ -277,6 +319,18 @@ async def discover_ramses_devices(hass: HomeAssistant) -> list[Any]:
             else:
                 broker = broker_data
             _LOGGER.debug("Found broker via hass.data method: %s", broker)
+
+            devices_list = _extract_devices_from_candidate(broker_data)
+            if devices_list:
+                device_ids = [
+                    getattr(device, "id", str(device)) for device in devices_list
+                ]
+                _LOGGER.info(
+                    "Found %d devices from hass.data for config flows: %s",
+                    len(devices_list),
+                    device_ids,
+                )
+                return devices_list
 
         if broker is None and hasattr(entry, "broker"):
             broker = entry.broker
@@ -306,20 +360,10 @@ async def discover_ramses_devices(hass: HomeAssistant) -> list[Any]:
             _LOGGER.warning("Could not find ramses_cc broker via any method")
             return await _discover_devices_from_entity_registry(hass)
 
-        devices = getattr(broker, "_devices", None)
-        if devices is None:
-            devices = getattr(broker, "devices", None)
-
-        if not devices:
+        devices_list = _extract_devices_from_candidate(broker)
+        if not devices_list:
             _LOGGER.debug("No devices found in broker, using entity registry fallback")
             return await _discover_devices_from_entity_registry(hass)
-
-        if isinstance(devices, dict):
-            devices_list = list(devices.values())
-        elif isinstance(devices, (list, set, tuple)):
-            devices_list = list(devices)
-        else:
-            devices_list = [devices]
 
         device_ids = [getattr(device, "id", str(device)) for device in devices_list]
         _LOGGER.info(

--- a/custom_components/ramses_extras/framework/setup/features.py
+++ b/custom_components/ramses_extras/framework/setup/features.py
@@ -126,9 +126,9 @@ async def load_feature_definitions_and_platforms(
 ) -> None:
     """Load feature definitions and set up platforms.
 
-    Registers default commands, loads enabled features, imports platform
-    modules, discovers devices, sets up platforms, and initializes
-    WebSocket integration.
+    Registers default commands, loads enabled features, initializes
+    WebSocket integration, imports platform modules, discovers devices,
+    and sets up platforms.
 
     :param hass: Home Assistant instance
     :param entry: Configuration entry
@@ -147,6 +147,10 @@ async def load_feature_definitions_and_platforms(
 
     await asyncio.to_thread(extras_registry.load_all_features, enabled_feature_names)
 
+    # Register websocket commands as early as possible after feature metadata
+    # is loaded so startup card probes (get_cards_enabled) can succeed sooner.
+    await setup_websocket_integration(hass)
+
     await import_feature_platform_modules(enabled_feature_names)
 
     await discover_and_store_devices_fn(hass)
@@ -155,8 +159,6 @@ async def load_feature_definitions_and_platforms(
         entry,
         [Platform.SENSOR, Platform.SWITCH, Platform.BINARY_SENSOR, Platform.NUMBER],
     )
-
-    await setup_websocket_integration(hass)
 
     sensor_count = len(extras_registry.get_all_sensor_configs())
     switch_count = len(extras_registry.get_all_switch_configs())

--- a/custom_components/ramses_extras/framework/www/ramses-base-card.js
+++ b/custom_components/ramses_extras/framework/www/ramses-base-card.js
@@ -543,6 +543,25 @@ export class RamsesBaseCard extends HTMLElement {
       return this._backendReadyPromise;
     }
 
+    window.ramsesExtras = window.ramsesExtras || {};
+    window.ramsesExtras._backendReadyFailCount = window.ramsesExtras._backendReadyFailCount || 0;
+    window.ramsesExtras._backendReadyLastFailTime = window.ramsesExtras._backendReadyLastFailTime || 0;
+
+    const failCount = window.ramsesExtras._backendReadyFailCount;
+    const lastFailTime = window.ramsesExtras._backendReadyLastFailTime;
+    const backoffTime = Math.min(60000, 1000 * Math.pow(2, failCount));
+    const elapsed = Date.now() - lastFailTime;
+    if (failCount >= 3 && elapsed < backoffTime) {
+      const retry_In = Math.max(1000, backoffTime - elapsed);
+      this._backendReadyPromise = new Promise((resolve) => {
+        setTimeout(() => {
+          this._backendReadyPromise = null;
+          resolve(this._confirmBackendReady());
+        }, retry_In);
+      });
+      return this._backendReadyPromise;
+    }
+
     logger.debug(`${this.constructor.name}: Calling get_cards_enabled to confirm backend ready`);
     this._backendReadyPromise = callWebSocket(this._hass, {
       type: 'ramses_extras/default/get_cards_enabled',
@@ -550,6 +569,8 @@ export class RamsesBaseCard extends HTMLElement {
       .then((result) => {
         logger.debug(`${this.constructor.name}: Backend ready confirmed, cards_enabled=${result?.cards_enabled}`);
         this._hassLoaded = true;
+        window.ramsesExtras._backendReadyFailCount = 0;
+        window.ramsesExtras._backendReadyLastFailTime = 0;
         this._backendReadyPromise = null;
 
         // Also set cardsEnabled if the response indicates it's enabled
@@ -562,13 +583,35 @@ export class RamsesBaseCard extends HTMLElement {
         this._scheduleRender();
       })
       .catch((error) => {
-        logger.warn(`${this.constructor.name}: Backend ready check failed, will retry:`, error);
+        window.ramsesExtras._backendReadyFailCount = (window.ramsesExtras._backendReadyFailCount || 0) + 1;
+        window.ramsesExtras._backendReadyLastFailTime = Date.now();
+
+        const errMsg = String(error?.message || '').toLowerCase();
+        const isUnknownCommand =
+          error?.code === 'unknown_command' ||
+          error?.not_available === true ||
+          errMsg.includes('unknown command');
+
+        if (isUnknownCommand) {
+          this._runOnce('backend-ready-unknown-command', () => {
+            logger.warn(
+              `${this.constructor.name}: Backend get_cards_enabled command not available yet; retrying with backoff`
+            );
+          });
+        } else {
+          logger.warn(`${this.constructor.name}: Backend ready check failed, will retry:`, error);
+        }
+
         this._backendReadyPromise = null;
+        const delayMs = Math.min(
+          60000,
+          1000 * Math.pow(2, Math.max(0, window.ramsesExtras._backendReadyFailCount - 1))
+        );
         // Return a new promise that will retry, so the original promise never rejects
         return new Promise((resolve) => {
           setTimeout(() => {
             resolve(this._confirmBackendReady());
-          }, 1000);
+          }, delayMs);
         });
       });
 

--- a/docs/notepad.txt
+++ b/docs/notepad.txt
@@ -100,9 +100,6 @@ we should be able to simulate and test this
 
 --- next to do:
 
-### check the profiles (like normal) if they are realistic
-
-### check the profiles if they have unknown entities (like fan) and create proper answers for this
 
 -- other:
 

--- a/docs/notepad.txt
+++ b/docs/notepad.txt
@@ -117,3 +117,40 @@ Verify logs: Saved original ramses_cc state for simulator cleanup (port=... sche
 Disable device_simulator or remove ramses_extras
 Verify logs: Restored ramses_cc schema/known_list/ramses_rf to pre-simulator state and Restored ramses_cc MQTT serial_port to <original>
 Check ramses_cc options match step 1
+
+
+
+_cc #654:
+
+on _cc when switching on: Log all MQTT traffic, i get the following error:
+2026-05-05 16:04:23.872 INFO (MainThread) [custom_components.ramses_cc.coordinator] Saving the client state cache (packets, schema)
+2026-05-05 16:04:23.874 WARNING (paho-mqtt-client-) [ramses_tx.transport.mqtt] MQTT disconnected: DisconnectFlags(is_disconnect_packet_from_server=False)
+2026-05-05 16:04:23.889 INFO (MainThread) [custom_components.ramses_cc.schemas] Using the cached schema
+2026-05-05 16:04:23.889 ERROR (MainThread) [custom_components.ramses_cc] Unexpected error during setup of entry 01KKP880DFBBWJTQHME175WF5V: Either a port_name or an input_file must be specified
+Traceback (most recent call last):
+  File "/config/custom_components/ramses_cc/__init__.py", line 164, in async_setup_entry
+    await coordinator.async_setup()
+  File "/config/custom_components/ramses_cc/coordinator.py", line 251, in async_setup
+    self.client = self._create_client(merged_schema)
+                  ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
+  File "/config/custom_components/ramses_cc/coordinator.py", line 411, in _create_client
+    return Gateway(
+        port_name=port_name,
+        config=gwy_config,
+        loop=self.hass.loop,
+    )
+  File "/usr/local/lib/python3.14/site-packages/ramses_rf/gateway.py", line 211, in __init__
+    self._engine = Engine(
+                   ~~~~~~^
+        self._gwy_config.engine,
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+        loop=loop,
+        ^^^^^^^^^^
+        transport_constructor=transport_constructor,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    )
+    ^
+  File "/usr/local/lib/python3.14/site-packages/ramses_tx/engine.py", line 80, in __init__
+    raise TypeError("Either a port_name or an input_file must be specified")
+TypeError: Either a port_name or an input_file must be specified
+2026-05-05 16:04:23.891 INFO (MainThread) [homeassistant.config_entries] Config entry 'RAMSES RF' for ramses_cc integration not ready yet: Setup failed: Either a port_name or an input_file must be specified; Retrying in 5 seconds

--- a/tests/features/device_simulator/test_init.py
+++ b/tests/features/device_simulator/test_init.py
@@ -18,6 +18,10 @@ from custom_components.ramses_extras.features.device_simulator import (
     create_device_simulator_feature,
     load_feature,
 )
+from custom_components.ramses_extras.features.device_simulator.const import (
+    SIMULATOR_HGI_ID,
+    SIMULATOR_TOPIC_NS,
+)
 
 
 class TestPreClearRamsesCcSchema:
@@ -176,6 +180,39 @@ class TestEnforceSimulatorIsolation:
                 RuntimeError, match="Failed to enforce simulator isolation"
             ):
                 await _enforce_simulator_isolation(hass)
+
+    @pytest.mark.asyncio
+    async def test_enforce_simulator_isolation_mqtt_ha_updates_topic_and_hgi(self):
+        """mqtt_ha transport should isolate via mqtt_topic/mqtt_hgi_id."""
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "test_entry"
+        entry.options = {
+            "serial_port": {"port_name": "mqtt_ha"},
+            "mqtt_use_ha": True,
+            "mqtt_topic": "RAMSES/GATEWAY",
+            "mqtt_hgi_id": "18:AAAAAA",
+        }
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_entries = MagicMock(return_value=[entry])
+        hass.config_entries.async_update_entry = MagicMock()
+        hass.config_entries.async_reload = AsyncMock()
+
+        with patch("homeassistant.helpers.storage.Store") as mock_store_class:
+            mock_store = MagicMock()
+            mock_store.async_load = AsyncMock(return_value={})
+            mock_store.async_save = AsyncMock()
+            mock_store_class.return_value = mock_store
+
+            result = await _enforce_simulator_isolation(hass)
+
+        assert result is True
+        updated_options = hass.config_entries.async_update_entry.call_args.kwargs[
+            "options"
+        ]
+        assert updated_options["mqtt_topic"] == SIMULATOR_TOPIC_NS
+        assert updated_options["mqtt_hgi_id"] == SIMULATOR_HGI_ID
+        hass.config_entries.async_reload.assert_awaited_once()
 
 
 class TestLoadFeature:
@@ -661,3 +698,44 @@ class TestRestoreGatewayTopic:
         assert updated_options["known_list"] == {"device": "class"}
         assert updated_options["ramses_rf"]["enforce_known_list"] is True
         assert updated_options["ramses_rf"]["enable_eavesdrop"] is False
+
+    @pytest.mark.asyncio
+    async def test_restore_gateway_restores_mqtt_ha_topic_and_hgi(self):
+        """Restore mqtt_ha transport metadata from saved state."""
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "test_entry"
+        entry.options = {
+            "serial_port": {"port_name": "mqtt_ha"},
+            "mqtt_use_ha": True,
+            "mqtt_topic": SIMULATOR_TOPIC_NS,
+            "mqtt_hgi_id": SIMULATOR_HGI_ID,
+        }
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_entries = MagicMock(return_value=[entry])
+        hass.config_entries.async_update_entry = MagicMock()
+        hass.config_entries.async_reload = AsyncMock()
+
+        with patch("homeassistant.helpers.storage.Store") as mock_store_class:
+            mock_store = MagicMock()
+            mock_store.async_load = AsyncMock(
+                return_value={
+                    "original_port_name": "mqtt_ha",
+                    "original_mqtt_topic": "RAMSES/GATEWAY",
+                    "original_mqtt_hgi_id": "18:ABCDEF",
+                    "state_saved": True,
+                }
+            )
+            mock_store.async_save = AsyncMock()
+            mock_store_class.return_value = mock_store
+
+            result = await async_restore_ramses_cc_gateway_topic(hass)
+
+        assert result is True
+        updated_options = hass.config_entries.async_update_entry.call_args.kwargs[
+            "options"
+        ]
+        assert updated_options["mqtt_topic"] == "RAMSES/GATEWAY"
+        assert updated_options["mqtt_hgi_id"] == "18:ABCDEF"
+        assert updated_options["serial_port"]["port_name"] == "mqtt_ha"
+        hass.config_entries.async_reload.assert_awaited_once()

--- a/tests/features/device_simulator/test_scenarios.py
+++ b/tests/features/device_simulator/test_scenarios.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1011,6 +1012,65 @@ class TestDiscoveryTest:
 
         assert result.success is True
         assert "37:168270" in result.details["device_id"]
+
+    @pytest.mark.asyncio
+    async def test_run_uses_active_device_when_missing_device_id(self):
+        """Ensure the scenario falls back to the first active device for a slug."""
+        hass = MagicMock()
+        engine = MagicMock()
+        engine.async_cancel_scenario = AsyncMock()
+        engine._active_devices = {
+            "32:150000": ActiveDevice(
+                device_id="32:150000", slug="FAN", variant_id="itho"
+            )
+        }
+        context = ScenarioContext(hass, engine)
+        context.device_db.find_response = MagicMock(return_value=None)
+
+        async def mock_create_task(coro, name):
+            await coro
+            return MagicMock()
+
+        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+
+        result = await discovery_test_run(context, {"slug": "fan"})
+
+        assert result.success is True
+        assert result.details["device_id"] == "32:150000"
+
+    @pytest.mark.asyncio
+    async def test_run_prefers_variant_payload(self):
+        """Payload resolves from the active device variant response if available."""
+        hass = MagicMock()
+        engine = MagicMock()
+        engine.async_cancel_scenario = AsyncMock()
+        engine._active_devices = {
+            "32:150000": ActiveDevice(
+                device_id="32:150000", slug="FAN", variant_id="itho"
+            )
+        }
+        context = ScenarioContext(hass, engine)
+        context.device_db.get_fingerprint_payload = MagicMock(return_value=None)
+
+        variant_response = SimpleNamespace(payloads=["00aabbcc"])
+
+        def _find_response(slug, code, variant):
+            if variant == "itho":
+                return variant_response
+            return None
+
+        context.device_db.find_response = MagicMock(side_effect=_find_response)
+
+        async def mock_create_task(coro, name):
+            await coro
+            return MagicMock()
+
+        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+
+        result = await discovery_test_run(context, {"slug": "FAN"})
+
+        assert result.success is True
+        assert result.details["payload"] == "00AABBCC"
 
     @pytest.mark.asyncio
     async def test_run_with_fingerprint(self):

--- a/tests/features/ramses_debugger/test_messages_provider.py
+++ b/tests/features/ramses_debugger/test_messages_provider.py
@@ -294,6 +294,8 @@ def test_silence_loggers_restores_state() -> None:
 
 def test_decode_message_with_ramses_rf_missing_module(monkeypatch) -> None:
     # Ensure import fails
+    monkeypatch.setitem(sys.modules, "ramses_rf", None)
+    monkeypatch.setitem(sys.modules, "ramses_rf.message", None)
     monkeypatch.setitem(sys.modules, "ramses_tx", None)
     monkeypatch.setitem(sys.modules, "ramses_tx.message", None)
     monkeypatch.setitem(sys.modules, "ramses_tx.packet", None)
@@ -548,6 +550,7 @@ def test_decode_message_with_ramses_rf_validation_returns_none(
 
 
 def test_decode_message_with_ramses_rf_success(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "ramses_rf.message", None)
     mod_packet = types.ModuleType("ramses_tx.packet")
     mod_message = types.ModuleType("ramses_tx.message")
 

--- a/tests/features/ramses_debugger/test_ramses_debugger_log.py
+++ b/tests/features/ramses_debugger/test_ramses_debugger_log.py
@@ -435,3 +435,69 @@ async def test_get_configured_packet_log_path_v2_preferred_over_v1(
 
     assert result is not None
     assert result == expected_v2_path
+
+
+@pytest.mark.asyncio
+async def test_get_configured_packet_log_path_defaults_when_path_empty(
+    hass, tmp_path: Path
+) -> None:
+    """If packet_log_path is empty, fall back to default packet_log.log locations."""
+    from custom_components.ramses_extras.features.ramses_debugger.log_backend import (
+        get_configured_packet_log_path,
+    )
+
+    expected = tmp_path / "packet_log.log"
+    expected.write_text("default location\n", encoding="utf-8")
+
+    fake_cc_entry = MagicMock()
+    fake_cc_entry.options = {
+        "packet_log": {
+            "packet_log_path": "",
+            "packet_log_prefix": "packet_log",
+        }
+    }
+    fake_cc_entry.data = {}
+
+    hass.config.path = MagicMock(
+        side_effect=lambda *parts: str(tmp_path / Path(*parts))
+    )
+
+    with patch.object(
+        hass.config_entries, "async_entries", return_value=[fake_cc_entry]
+    ):
+        result = get_configured_packet_log_path(hass)
+
+    assert result is not None
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_get_configured_packet_log_path_reads_entry_data(
+    hass, tmp_path: Path
+) -> None:
+    """Use ramses_cc entry.data packet_log when options are empty."""
+    from custom_components.ramses_extras.features.ramses_debugger.log_backend import (
+        get_configured_packet_log_path,
+    )
+
+    packet_dir = tmp_path / "rf_logs"
+    packet_dir.mkdir()
+    expected = packet_dir / "custom_prefix.log"
+    expected.write_text("from data\n", encoding="utf-8")
+
+    fake_cc_entry = MagicMock()
+    fake_cc_entry.options = {}
+    fake_cc_entry.data = {
+        "packet_log": {
+            "path": str(packet_dir),
+            "prefix": "custom_prefix",
+        }
+    }
+
+    with patch.object(
+        hass.config_entries, "async_entries", return_value=[fake_cc_entry]
+    ):
+        result = get_configured_packet_log_path(hass)
+
+    assert result is not None
+    assert result == expected

--- a/tests/framework/test_devices_setup.py
+++ b/tests/framework/test_devices_setup.py
@@ -31,6 +31,24 @@ async def test_async_setup_platforms_uses_cached_devices(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_setup_platforms_rediscovers_when_cached_empty(hass) -> None:
+    """Empty cached device list should not block a fresh discovery."""
+    hass.config.components.add("ramses_cc")
+    hass.data.setdefault(DOMAIN, {})["devices"] = []
+    hass.data[DOMAIN]["device_discovery_complete"] = True
+
+    discovered = [MagicMock(id="32:000001")]
+    with patch(
+        "custom_components.ramses_extras.framework.setup.devices.discover_ramses_devices",
+        new=AsyncMock(return_value=discovered),
+    ) as discover:
+        await devices.async_setup_platforms(hass)
+
+    discover.assert_awaited_once()
+    assert hass.data[DOMAIN]["devices"] == discovered
+
+
+@pytest.mark.asyncio
 async def test_async_setup_platforms_retries_when_not_loaded(hass) -> None:
     hass.config.components.clear()
 
@@ -340,6 +358,27 @@ async def test_discover_ramses_devices_broker_devices_attr(hass) -> None:
     result = await devices.discover_ramses_devices(hass)
 
     assert [getattr(d, "id", d) for d in result] == ["devices_attr"]
+
+
+@pytest.mark.asyncio
+async def test_discover_ramses_devices_from_coordinator_client(hass) -> None:
+    """Support coordinator-shaped hass.data entries with devices on .client."""
+
+    class Client:
+        def __init__(self) -> None:
+            self.devices = [MagicMock(id="client_device")]
+
+    class Coordinator:
+        def __init__(self) -> None:
+            self.client = Client()
+
+    entry = MagicMock(entry_id="1")
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+    hass.data.setdefault("ramses_cc", {})["1"] = Coordinator()
+
+    result = await devices.discover_ramses_devices(hass)
+
+    assert [getattr(d, "id", d) for d in result] == ["client_device"]
 
 
 @pytest.mark.asyncio

--- a/tests/framework/test_ramses_message_stream.py
+++ b/tests/framework/test_ramses_message_stream.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from custom_components.ramses_extras.framework.helpers.ramses_message_stream import (
     RamsesMessageStream,
@@ -145,6 +147,46 @@ class TestRamsesMessageStream:
         stream._handle_ramses_cc_message(event)
 
         callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_attach_client_listener_retries_until_available(self) -> None:
+        """Listener attachment should retry while coordinator/client initializes."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+
+        unsub = MagicMock()
+        coordinator = SimpleNamespace(
+            client=SimpleNamespace(add_msg_handler=MagicMock(return_value=unsub))
+        )
+
+        with patch(
+            "custom_components.ramses_extras.framework.helpers.ramses_message_stream.RamsesCommands"
+        ) as mock_commands_cls:
+            mock_commands = mock_commands_cls.return_value
+            mock_commands._get_ramses_cc_coordinator = AsyncMock(
+                side_effect=[None, coordinator]
+            )
+
+            with patch(
+                "custom_components.ramses_extras.framework.helpers.ramses_message_stream.asyncio.sleep",
+                new=AsyncMock(),
+            ) as sleep_mock:
+                await stream._async_attach_client_listener()
+
+        assert stream._msg_handler_unsub is unsub
+        assert sleep_mock.await_count == 1
+
+    def test_resolve_add_msg_handler_prefers_coordinator_when_available(self) -> None:
+        """Support coordinator shapes exposing add_msg_handler directly."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+        add_handler = MagicMock()
+        coordinator = MagicMock()
+        coordinator.add_msg_handler = add_handler
+
+        resolved = stream._resolve_add_msg_handler(coordinator)
+
+        assert resolved is add_handler
 
     def test_start_already_started(self) -> None:
         """Test start does nothing if already started."""

--- a/tests/framework/test_ramses_message_stream.py
+++ b/tests/framework/test_ramses_message_stream.py
@@ -68,6 +68,36 @@ class TestRamsesMessageStream:
 
         data = callback.call_args.args[0]
         assert data["src"] == "32:150000"
+
+    def test_handle_msg_with_dto_shape(self) -> None:
+        """Test _handle_msg handles PacketDTO-like objects."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+        callback = MagicMock()
+        stream.subscribe(callback)
+
+        msg = SimpleNamespace(
+            addr1="32:150000",
+            addr2="37:170000",
+            verb="RP",
+            code="2411",
+            payload="00003E",
+            timestamp=datetime(2026, 4, 18, 9, 0, 0),
+        )
+
+        stream._handle_msg(msg)
+
+        callback.assert_called_once()
+        data = callback.call_args.args[0]
+        assert data["src"] == "32:150000"
+        assert data["dst"] == "37:170000"
+        assert data["verb"] == "RP"
+        assert data["code"] == "2411"
+        assert data["payload"] == "00003E"
+        assert (
+            data["frame"] == "000 RP --- 32:150000 37:170000 --:------ 2411 003 00003E"
+        )
+        assert data["dtm"] == "2026-04-18T09:00:00.000000"
         assert data["dst"] == "37:170000"
 
     def test_event_path_kept_for_requests_when_handler_attached(self) -> None:

--- a/tests/test_main_init.py
+++ b/tests/test_main_init.py
@@ -648,7 +648,7 @@ class TestDiscoverDevices:
         mock_broker = MagicMock()
         mock_device = MagicMock()
         mock_device.id = "32:111111"
-        mock_broker.broker._devices = [mock_device]
+        mock_broker._devices = [mock_device]  # Set _devices directly on broker
 
         hass.config_entries.async_entries = MagicMock(return_value=[mock_entry])
         hass.data["ramses_cc"] = {"test_entry": mock_broker}


### PR DESCRIPTION
Impacts from the recent _rf/_cc transport-layer changes on ramses_extras simulator/debugger.

Findings

High: live message ingestion path is now incompatible with DTO callbacks
_cc now feeds PacketDTO into add_msg_handler callbacks (e.g. async_process_msg(dto: PacketDTO) in ramses_cc/custom_components/ramses_cc/event.py:182).
In _rf, protocol dispatch also passes DTOs (PacketDTO) to handlers in ramses_rf/src/ramses_tx/protocol/base.py:424.
But extras stream handler still expects legacy message objects (msg._pkt, msg.src.id, msg.dst.id) in ramses_extras/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py:153.
Result: src/dst/frame often become missing, and debugger collector drops those records (traffic_collector.py:243).
This likely degrades/empties debugger live traffic (especially RP/I path) and also impacts simulator “processed frame” stream consumers.
High: decoder import path changed (silent feature degradation)
_rf moved/deleted ramses_tx.message (Message now under ramses_rf.message).
Extras still imports from ramses_tx.message import Message in:
ramses_extras/custom_components/ramses_extras/features/ramses_debugger/messages_provider.py:221
ramses_extras/custom_components/ramses_extras/features/device_simulator/message_log.py:79
These functions catch ModuleNotFoundError, so no hard crash, but payload decoding falls back to None (silent loss of decoded views).
Low: transport/gateway constructor-level compatibility looks okay
coordinator.client still exists (ramses_cc/custom_components/ramses_cc/coordinator.py:107).
add_msg_handler() still exists and returns an unsub callable (ramses_rf/src/ramses_rf/gateway.py:793).
MQTT transport shape (msg JSON wrapper, topic structure) still aligns with simulator endpoint expectations; no obvious break there.
Bottom line

For simulator/debugger, the biggest regression risk is message stream ingestion/parsing, not transport bring-up.
I’d treat this as a must-fix compatibility patch for extras before relying on debugger traffic or simulator processed-stream behavior.


- Make RamsesMessageStream._handle_msg() DTO-aware (PacketDTO fields: addr1/addr2/addr3, timestamp, etc.).
- Add dual import fallback for Message (ramses_rf.message first, then legacy ramses_tx.message) in debugger + simulator decoders.
- Add targeted tests for both legacy-style and DTO-style callback payloads.
