### PR TITLE
fix issue 86

### DIFF
--- a/custom_components/ramses_extras/features/default/services.py
+++ b/custom_components/ramses_extras/features/default/services.py
@@ -509,8 +509,13 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         )
 
     def _handle_remote_msg(msg: object, *args: object, **kwargs: object) -> None:
-        src = getattr(getattr(msg, "src", None), "id", None)
-        dst = getattr(getattr(msg, "dst", None), "id", None)
+        # PacketDTO uses addr1/addr2 (str); Message uses src/dst (Address.id)
+        src = getattr(msg, "addr1", None)
+        if src is None:
+            src = getattr(getattr(msg, "src", None), "id", None)
+        dst = getattr(msg, "addr2", None)
+        if dst is None:
+            dst = getattr(getattr(msg, "dst", None), "id", None)
         code = getattr(msg, "code", None)
         payload = getattr(msg, "payload", None)
         verb = getattr(msg, "verb", None)

--- a/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py
+++ b/custom_components/ramses_extras/framework/helpers/ramses_message_stream.py
@@ -1,14 +1,43 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+from homeassistant.loader import async_get_integration
 
 from ...const import DOMAIN
 from .ramses_commands import RamsesCommands
+
+_LOGGER = logging.getLogger(__name__)
+
+# ramses_cc 0.55.6 removed ramses_cc_message HA bus events and replaced
+# them with HA Event Entities.  Before this version, ramses_cc itself
+# fired ramses_cc_message events on the HA bus (when MESSAGE_EVENTS was
+# enabled in advanced config).  After this version, the only way to
+# receive messages is via coordinator.client.add_msg_handler().
+_RAMSES_CC_MESSAGE_EVENTS_REMOVED = "0.55.6"
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Convert a dotted version string to a comparable tuple."""
+    parts: list[int] = []
+    for part in version.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            # Strip non-numeric suffixes (e.g. "0.55.6-beta" → 0.55.6)
+            numeric = ""
+            for ch in part:
+                if ch.isdigit():
+                    numeric += ch
+                else:
+                    break
+            parts.append(int(numeric) if numeric else 0)
+    return tuple(parts)
 
 
 class RamsesMessageStream:
@@ -19,6 +48,9 @@ class RamsesMessageStream:
         self._subscribers: dict[int, Callable[[dict[str, Any]], None]] = {}
         self._next_subscription_id = 0
         self._attach_task = None
+        # None = not yet checked, True/False = ramses_cc fires its own
+        # ramses_cc_message HA bus events
+        self._ramses_cc_fires_events: bool | None = None
 
     def start(self) -> None:
         if self._event_unsub is not None or self._msg_handler_unsub is not None:
@@ -54,6 +86,39 @@ class RamsesMessageStream:
 
         return _unsub
 
+    async def _async_ramses_cc_fires_events(self) -> bool:
+        """Check whether ramses_cc fires ramses_cc_message HA bus events.
+
+        ramses_cc < 0.55.6 fired these events when MESSAGE_EVENTS was
+        enabled.  ramses_cc >= 0.55.6 removed them entirely.  We detect
+        the version at runtime via the integration manifest.
+        """
+        if self._ramses_cc_fires_events is not None:
+            return self._ramses_cc_fires_events
+
+        try:
+            integration = await async_get_integration(self._hass, "ramses_cc")
+            version = integration.manifest.get("version", "0.0.0")
+            if isinstance(version, str) and version:
+                fires = _version_tuple(version) < _version_tuple(
+                    _RAMSES_CC_MESSAGE_EVENTS_REMOVED
+                )
+                self._ramses_cc_fires_events = fires
+                _LOGGER.debug(
+                    "ramses_cc version %s fires_message_events=%s",
+                    version,
+                    fires,
+                )
+                return fires
+        except Exception as e:
+            _LOGGER.debug(
+                "Could not determine ramses_cc version, assuming no bus events: %s",
+                e,
+            )
+
+        self._ramses_cc_fires_events = False
+        return False
+
     def _resolve_add_msg_handler(self, coordinator: Any) -> Callable[..., Any] | None:
         if coordinator is None:
             return None
@@ -75,7 +140,7 @@ class RamsesMessageStream:
 
         for _ in range(max_attempts):
             if self._msg_handler_unsub is not None:
-                return
+                break
 
             coordinator = await commands._get_ramses_cc_coordinator()
             add_msg_handler = self._resolve_add_msg_handler(coordinator)
@@ -83,9 +148,14 @@ class RamsesMessageStream:
                 msg_handler_unsub = add_msg_handler(self._handle_msg)
                 if callable(msg_handler_unsub):
                     self._msg_handler_unsub = msg_handler_unsub
-                    return
+                    break
 
             await asyncio.sleep(1)
+
+        # Detect ramses_cc version to decide whether we need to fire
+        # ramses_cc_message HA bus events ourselves (newer versions) or
+        # rely on ramses_cc firing them (older versions).
+        await self._async_ramses_cc_fires_events()
 
     def inject(self, data: dict[str, Any]) -> None:
         """Inject a message directly to all subscribers.
@@ -169,6 +239,11 @@ class RamsesMessageStream:
     def _handle_ramses_cc_message(self, event: Event[dict[str, Any]]) -> None:
         data = dict(event.data or {})
         data["time_fired"] = event.time_fired.isoformat(timespec="microseconds")
+        # Skip events that were fired by _handle_msg (via add_msg_handler)
+        # to avoid duplicate subscriber notifications.  Events from other
+        # sources (e.g. outbound RQ from ramses_cc) are still processed.
+        if data.get("_from_msg_handler"):
+            return
         verb = data.get("verb")
         verb_upper = verb.upper().strip() if isinstance(verb, str) else None
         if self._msg_handler_unsub is not None and verb_upper in {"RP", "I"}:
@@ -189,13 +264,13 @@ class RamsesMessageStream:
         payload = getattr(pkt, "payload", None)
         if payload is None:
             payload = getattr(msg, "payload", None)
-        data = parsed or {
-            "src": self._extract_msg_addr(msg, "src", "addr1"),  # type: ignore[dict-item]
-            "dst": self._extract_msg_addr(msg, "dst", "addr2"),  # type: ignore[dict-item]
-            "verb": str(getattr(msg, "verb", "")) or None,  # type: ignore[dict-item]
-            "code": str(getattr(msg, "code", "")) or None,  # type: ignore[dict-item]
+        data: dict[str, Any] = parsed or {
+            "src": self._extract_msg_addr(msg, "src", "addr1"),
+            "dst": self._extract_msg_addr(msg, "dst", "addr2"),
+            "verb": str(getattr(msg, "verb", "")) or None,
+            "code": str(getattr(msg, "code", "")) or None,
         }
-        data["payload"] = str(payload) if payload is not None else None  # type: ignore[assignment]
+        data["payload"] = str(payload) if payload is not None else None
 
         if "frame" not in data:
             frame = self._frame_from_dict(data)
@@ -215,6 +290,27 @@ class RamsesMessageStream:
             data["dtm"] = dtm
 
         self._notify_subscribers(data)
+
+        # Fire on HA event bus so frontend components (e.g. the HVAC Fan
+        # Card's message broker) can receive real-time message data via
+        # WebSocket subscription.
+        #
+        # Version-aware logic:
+        # - ramses_cc >= 0.55.6 (_ramses_cc_fires_events=False): ramses_cc
+        #   no longer fires ramses_cc_message events, so we must fire them
+        #   here for the frontend.  The _from_msg_handler marker lets
+        #   _handle_ramses_cc_message skip this event to avoid duplicates.
+        # - ramses_cc < 0.55.6 (_ramses_cc_fires_events=True): ramses_cc
+        #   fires these events itself (when MESSAGE_EVENTS is enabled), so
+        #   we skip firing to avoid duplicates.  If MESSAGE_EVENTS is not
+        #   enabled, the frontend falls back to entity states.
+        # - Unknown (None): fire for safety until version is determined.
+        if self._ramses_cc_fires_events is not True:
+            try:
+                data["_from_msg_handler"] = True
+                self._hass.bus.async_fire("ramses_cc_message", data)
+            except Exception:
+                pass
 
 
 def get_ramses_message_stream(hass: HomeAssistant) -> RamsesMessageStream:

--- a/custom_components/ramses_extras/manifest.json
+++ b/custom_components/ramses_extras/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wimpie70/ramses_extras/issues",
   "requirements": [],
-  "version": "0.20.0"
+  "version": "0.20.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ramses_extras"
-version = "0.20.0"
+version = "0.20.1"
 description = "Extra features for Ramses CC integration"
 authors = ["Willem (wimpie70)"]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="ramses_extras",
-    version="0.20.0",
+    version="0.20.1",
     packages=[
         "custom_components.ramses_extras",
         "custom_components.ramses_extras.framework",

--- a/tests/framework/test_ramses_message_stream.py
+++ b/tests/framework/test_ramses_message_stream.py
@@ -148,6 +148,110 @@ class TestRamsesMessageStream:
 
         callback.assert_not_called()
 
+    def test_handle_msg_fires_ha_bus_event(self) -> None:
+        """_handle_msg should fire ramses_cc_message on the HA bus for frontend
+        when ramses_cc >= 0.55.6 (no longer fires its own events)."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+        stream._ramses_cc_fires_events = False  # newer ramses_cc
+        callback = MagicMock()
+        stream.subscribe(callback)
+
+        msg = SimpleNamespace(
+            addr1="32:150000",
+            addr2="37:170000",
+            verb="RP",
+            code="31DA",
+            payload="00EF007FFF3F3009BA0A8209690A256000C81822110000EFEF04C6076000",
+            timestamp=datetime(2026, 6, 23, 21, 28, 40),
+        )
+
+        stream._handle_msg(msg)
+
+        # Python subscribers notified
+        callback.assert_called_once()
+        # HA bus event fired for frontend message broker
+        hass.bus.async_fire.assert_called_once()
+        fired_event = hass.bus.async_fire.call_args
+        assert fired_event.args[0] == "ramses_cc_message"
+        fired_data = fired_event.kwargs.get("data") or fired_event.args[1]
+        assert fired_data["code"] == "31DA"
+        assert fired_data["src"] == "32:150000"
+        assert fired_data["_from_msg_handler"] is True
+
+    def test_handle_msg_skips_ha_bus_event_for_older_ramses_cc(self) -> None:
+        """_handle_msg should NOT fire ramses_cc_message on the HA bus when
+        ramses_cc < 0.55.6 (it fires its own events)."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+        stream._ramses_cc_fires_events = True  # older ramses_cc
+        callback = MagicMock()
+        stream.subscribe(callback)
+
+        msg = SimpleNamespace(
+            addr1="32:150000",
+            addr2="37:170000",
+            verb="RP",
+            code="31DA",
+            payload="00EF00",
+            timestamp=datetime(2026, 6, 23, 21, 28, 40),
+        )
+
+        stream._handle_msg(msg)
+
+        # Python subscribers still notified
+        callback.assert_called_once()
+        # HA bus event NOT fired (ramses_cc fires its own)
+        hass.bus.async_fire.assert_not_called()
+
+    def test_handle_msg_fires_event_when_version_unknown(self) -> None:
+        """_handle_msg should fire HA bus event when version is not yet
+        determined (default to firing for safety)."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+        # _ramses_cc_fires_events is None (not yet checked)
+        callback = MagicMock()
+        stream.subscribe(callback)
+
+        msg = SimpleNamespace(
+            addr1="32:150000",
+            addr2="37:170000",
+            verb="RP",
+            code="31DA",
+            payload="00EF00",
+            timestamp=datetime(2026, 6, 23, 21, 28, 40),
+        )
+
+        stream._handle_msg(msg)
+
+        callback.assert_called_once()
+        # Should fire because None is not False
+        hass.bus.async_fire.assert_called_once()
+
+    def test_handle_ramses_cc_message_skips_msg_handler_events(self) -> None:
+        """Events fired by _handle_msg should not duplicate subscriber notifications."""
+        hass = MagicMock()
+        hass.bus.async_listen = MagicMock()
+        stream = RamsesMessageStream(hass)
+        callback = MagicMock()
+        stream.subscribe(callback)
+
+        event = SimpleNamespace(
+            data={
+                "src": "32:150000",
+                "dst": "37:170000",
+                "verb": "RP",
+                "code": "31DA",
+                "payload": "00EF00",
+                "_from_msg_handler": True,
+            },
+            time_fired=datetime(2026, 6, 23, 21, 28, 40),
+        )
+
+        stream._handle_ramses_cc_message(event)
+
+        callback.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_attach_client_listener_retries_until_available(self) -> None:
         """Listener attachment should retry while coordinator/client initializes."""
@@ -171,10 +275,16 @@ class TestRamsesMessageStream:
                 "custom_components.ramses_extras.framework.helpers.ramses_message_stream.asyncio.sleep",
                 new=AsyncMock(),
             ) as sleep_mock:
-                await stream._async_attach_client_listener()
+                with patch(
+                    "custom_components.ramses_extras.framework.helpers.ramses_message_stream.async_get_integration",
+                    new=AsyncMock(side_effect=Exception("not found")),
+                ):
+                    await stream._async_attach_client_listener()
 
         assert stream._msg_handler_unsub is unsub
         assert sleep_mock.await_count == 1
+        # Version detection ran but defaulted to False (no bus events)
+        assert stream._ramses_cc_fires_events is False
 
     def test_resolve_add_msg_handler_prefers_coordinator_when_available(self) -> None:
         """Support coordinator shapes exposing add_msg_handler directly."""
@@ -187,6 +297,70 @@ class TestRamsesMessageStream:
         resolved = stream._resolve_add_msg_handler(coordinator)
 
         assert resolved is add_handler
+
+    @pytest.mark.asyncio
+    async def test_ramses_cc_fires_events_old_version(self) -> None:
+        """Older ramses_cc (< 0.55.6) fires its own ramses_cc_message events."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+
+        integration = SimpleNamespace(manifest={"version": "0.55.5"})
+        with patch(
+            "custom_components.ramses_extras.framework.helpers.ramses_message_stream.async_get_integration",
+            new=AsyncMock(return_value=integration),
+        ):
+            result = await stream._async_ramses_cc_fires_events()
+
+        assert result is True
+        assert stream._ramses_cc_fires_events is True
+
+    @pytest.mark.asyncio
+    async def test_ramses_cc_fires_events_new_version(self) -> None:
+        """Newer ramses_cc (>= 0.55.6) does not fire ramses_cc_message events."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+
+        integration = SimpleNamespace(manifest={"version": "0.55.6"})
+        with patch(
+            "custom_components.ramses_extras.framework.helpers.ramses_message_stream.async_get_integration",
+            new=AsyncMock(return_value=integration),
+        ):
+            result = await stream._async_ramses_cc_fires_events()
+
+        assert result is False
+        assert stream._ramses_cc_fires_events is False
+
+    @pytest.mark.asyncio
+    async def test_ramses_cc_fires_events_not_installed(self) -> None:
+        """When ramses_cc is not found, default to not firing events."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+
+        with patch(
+            "custom_components.ramses_extras.framework.helpers.ramses_message_stream.async_get_integration",
+            new=AsyncMock(side_effect=Exception("not found")),
+        ):
+            result = await stream._async_ramses_cc_fires_events()
+
+        assert result is False
+        assert stream._ramses_cc_fires_events is False
+
+    @pytest.mark.asyncio
+    async def test_ramses_cc_fires_events_caches_result(self) -> None:
+        """Version detection result should be cached."""
+        hass = MagicMock()
+        stream = RamsesMessageStream(hass)
+        stream._ramses_cc_fires_events = True  # already set
+
+        # Should return cached value without calling async_get_integration
+        with patch(
+            "custom_components.ramses_extras.framework.helpers.ramses_message_stream.async_get_integration",
+            new=AsyncMock(),
+        ) as mock_get:
+            result = await stream._async_ramses_cc_fires_events()
+
+        assert result is True
+        mock_get.assert_not_called()
 
     def test_start_already_started(self) -> None:
         """Test start does nothing if already started."""


### PR DESCRIPTION
see issue #86 

Ramses_cc versions < 0.55.6 use the depleted ramses_cc_message HA bus events.

The fix is already described in the issue but since Ramses RF is still not stable for all systems and users may still use older versions, we also need to be version aware:

Version-Aware Implementation
Modified ramses_message_stream.py to detect the ramses_cc version at runtime via async_get_integration(hass, "ramses_cc") and behave accordingly:

For ramses_cc >= 0.55.6 (_ramses_cc_fires_events = False):

_handle_msg fires ramses_cc_message HA bus events itself (since ramses_cc no longer does)
Frontend cards receive real-time 31DA/10D0 data via WebSocket subscription
The _from_msg_handler marker prevents duplicate subscriber notifications
For ramses_cc < 0.55.6 (_ramses_cc_fires_events = True):

_handle_msg does NOT fire HA bus events (ramses_cc fires them itself)
_handle_ramses_cc_message processes events from ramses_cc
add_msg_handler is still used as a secondary path for RP/I messages
Version unknown (_ramses_cc_fires_events = None):

Fires events for safety until version is determined