### PR TITLE
add dewpoint guard

### DIFF
--- a/custom_components/ramses_extras/features/temp_control/automation.py
+++ b/custom_components/ramses_extras/features/temp_control/automation.py
@@ -13,6 +13,7 @@ conditions allow it.
 from __future__ import annotations
 
 import logging
+import math
 import time
 from collections.abc import Mapping
 from dataclasses import asdict
@@ -42,6 +43,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class TempControlAutomationManager(ExtrasBaseAutomation):
+    @staticmethod
+    def _calc_dewpoint_c(temp_c: float, rh_percent: float) -> float | None:
+        if not (0.0 < rh_percent <= 100.0):
+            return None
+        a = 17.62
+        b = 243.12
+        gamma = (a * temp_c) / (b + temp_c) + math.log(rh_percent / 100.0)
+        return (b * gamma) / (a - gamma)
+
     def __init__(self, hass: HomeAssistant, config_entry: Any) -> None:
         super().__init__(
             hass=hass,
@@ -326,6 +336,7 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
         outdoor_temp = float(entity_states["outdoor_temp"])
         supply_temp = float(entity_states["supply_temp"])
         comfort_temp = float(entity_states["comfort_temp"])
+        indoor_rh = float(entity_states["indoor_rh"])
 
         # Per-area evaluation: if sensor_control areas are configured with
         # temperature entities, evaluate each area separately and aggregate.
@@ -381,6 +392,15 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
 
             # Clear any stale zone demands when running in single-target mode
             await self._clear_all_zone_demands(device_id)
+
+        if desired_mode == "cooling" and getattr(
+            settings, "dewpoint_guard_enabled", False
+        ):
+            dewpoint = self._calc_dewpoint_c(indoor_temp, indoor_rh)
+            margin = float(getattr(settings, "dewpoint_margin_c", 1.0))
+            if dewpoint is not None and supply_temp < dewpoint + margin:
+                desired_mode = "idle"
+                await self._clear_all_zone_demands(device_id)
 
         # Enforce minimum interval between bypass mode changes
         last_change = self._last_bypass_change.get(device_id, 0.0)

--- a/custom_components/ramses_extras/features/temp_control/config.py
+++ b/custom_components/ramses_extras/features/temp_control/config.py
@@ -23,6 +23,8 @@ class TempControlSettings:
     cooling_delta_deactivate: float
     min_outdoor_temp: float
     min_bypass_mode_interval_seconds: int
+    dewpoint_guard_enabled: bool
+    dewpoint_margin_c: float
     default_desired_speed: str = "high"
 
 
@@ -53,6 +55,14 @@ class TempControlConfig:
             except TypeError, ValueError:
                 return int(default)
 
+        def _get_bool(key: str, default: bool) -> bool:
+            raw = section.get(key, TEMP_CONTROL_DEFAULTS.get(key, default))
+            if isinstance(raw, bool):
+                return raw
+            if raw is None:
+                return bool(default)
+            return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
         return TempControlSettings(
             comfort_delta_activate=_get_float("comfort_delta_activate", 1.0),
             comfort_delta_deactivate=_get_float("comfort_delta_deactivate", 0.5),
@@ -62,6 +72,8 @@ class TempControlConfig:
             min_bypass_mode_interval_seconds=_get_int(
                 "min_bypass_mode_interval_seconds", 180
             ),
+            dewpoint_guard_enabled=_get_bool("dewpoint_guard_enabled", False),
+            dewpoint_margin_c=_get_float("dewpoint_margin_c", 1.0),
             default_desired_speed=str(section.get("default_desired_speed", "high")),
         )
 

--- a/custom_components/ramses_extras/features/temp_control/config_flow.py
+++ b/custom_components/ramses_extras/features/temp_control/config_flow.py
@@ -41,6 +41,8 @@ def _get_section_defaults(flow: Any) -> dict[str, Any]:
             section.get("min_bypass_mode_interval_seconds", 180)
         ),
         "default_desired_speed": str(section.get("default_desired_speed", "high")),
+        "dewpoint_guard_enabled": bool(section.get("dewpoint_guard_enabled", False)),
+        "dewpoint_margin_c": float(section.get("dewpoint_margin_c", 1.0)),
     }
 
 
@@ -129,6 +131,14 @@ async def async_step_temp_control_config(
                 user_input["min_bypass_mode_interval_seconds"]
             ),
             "default_desired_speed": str(user_input["default_desired_speed"]),
+            "dewpoint_guard_enabled": bool(
+                user_input.get(
+                    "dewpoint_guard_enabled", defaults["dewpoint_guard_enabled"]
+                )
+            ),
+            "dewpoint_margin_c": float(
+                user_input.get("dewpoint_margin_c", defaults["dewpoint_margin_c"])
+            ),
         }
         _persist_temp_control_settings(flow, settings)
 
@@ -182,6 +192,12 @@ async def async_step_temp_control_config(
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
+            vol.Required(
+                "dewpoint_guard_enabled", default=defaults["dewpoint_guard_enabled"]
+            ): bool,
+            vol.Required(
+                "dewpoint_margin_c", default=defaults["dewpoint_margin_c"]
+            ): vol.Coerce(float),
         }
     )
 

--- a/custom_components/ramses_extras/features/temp_control/const.py
+++ b/custom_components/ramses_extras/features/temp_control/const.py
@@ -79,6 +79,8 @@ TEMP_CONTROL_DEFAULTS: dict[str, Any] = {
     "min_outdoor_temp": 10.0,
     "min_bypass_mode_interval_seconds": 180,
     "default_desired_speed": "high",
+    "dewpoint_guard_enabled": False,
+    "dewpoint_margin_c": 1.0,
 }
 
 FEATURE_DEFINITION: dict[str, Any] = {

--- a/custom_components/ramses_extras/framework/setup/entry.py
+++ b/custom_components/ramses_extras/framework/setup/entry.py
@@ -482,6 +482,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             Platform.SWITCH,
             Platform.BINARY_SENSOR,
             Platform.NUMBER,
+            Platform.SELECT,
         ],
     )
 

--- a/custom_components/ramses_extras/manifest.json
+++ b/custom_components/ramses_extras/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wimpie70/ramses_extras/issues",
   "requirements": [],
-  "version": "0.20.1"
+  "version": "0.20.2"
 }

--- a/docs/TEMP_CONTROL_FEATURE_PLAN.md
+++ b/docs/TEMP_CONTROL_FEATURE_PLAN.md
@@ -8,6 +8,7 @@
 > | §5 Entities & data model (switch/select/binary_sensor/sensor) | ✅ Done |
 > | §6 Configuration keys (config.py) | ✅ Done |
 > | §7 Automation logic (state machine, manual override, speed gating) | ✅ Done (runtime validated) |
+> | §7.7 Dewpoint guard (condensation protection) | ✅ Done (optional, opt-in) |
 > | §8.1 Register in `AVAILABLE_FEATURES` | ✅ Done |
 > | §8.2 Main options-menu entry + translations | ✅ Done |
 > | §8.3 Feature-specific config flow | ✅ Done (includes default_desired_speed selector) |
@@ -150,6 +151,8 @@ Thermal logic (hysteresis):
 Safety:
 
 - `min_outdoor_temp`: float (°C) — default `10.0` — do not force bypass open if outdoor air is too cold
+- `dewpoint_guard_enabled`: bool — default `False` — when enabled, blocks cooling if condensation risk is high (see §7.7)
+- `dewpoint_margin_c`: float (°C) — default `1.0` — safety margin added to the indoor dew point for the condensation guard
 
 Stability:
 
@@ -230,6 +233,46 @@ Backend behavior when temp_control is disabled:
 - Clear all zone demands (DemandSource.OTHER).
 - Return bypass to `auto`.
 
+### 7.7 Dewpoint guard (condensation protection)
+
+When `dewpoint_guard_enabled` is `True`, temp_control adds a condensation safety check before forcing bypass open for cooling.
+
+**Physical rationale:**
+
+- Bypass open → cold outdoor air flows through the supply ducts.
+- Ducts and internal surfaces cool down towards the supply air temperature.
+- Warm, humid indoor air contacts those cold surfaces.
+- If `supply_temp < indoor_dewpoint + margin`, condensation forms on cold ducts/surfaces.
+
+**Computation:**
+
+- Indoor dew point is calculated from `indoor_temp` + `indoor_rh` using the Magnus formula:
+
+  ```
+  a = 17.62, b = 243.12
+  gamma = (a * T) / (b + T) + ln(RH / 100)
+  dewpoint = (b * gamma) / (a - gamma)
+  ```
+
+- If `supply_temp < indoor_dewpoint + dewpoint_margin_c`, the desired mode is forced back to `idle` (bypass auto) and zone demands are cleared.
+
+**Why indoor (not outdoor) dewpoint:**
+
+- The condensation risk is indoor moisture condensing on cold supply surfaces.
+- Outdoor air at 6°C/100% RH has dewpoint 6°C, but when it enters a 22°C house it warms up and RH drops to ~30% — that air itself won't cause condensation.
+- The relevant comparison is: how cold do surfaces get (`supply_temp`) vs. how much moisture is already in the house (`indoor_dewpoint`).
+
+**Important note on `supply_temp`:**
+
+- The guard relies on `supply_temp` reflecting the actual supply air temperature after bypass open.
+- When bypass is open (no heat recovery), supply_temp should approach outdoor_temp.
+- If `supply_temp` is not available or not updating (e.g. sensor unavailable), the guard may not trigger as expected. Ensure `sensor.<device>_supply_temp` is populated.
+
+**Configuration:**
+
+- `dewpoint_guard_enabled`: bool (default `False`) — opt-in.
+- `dewpoint_margin_c`: float °C (default `1.0`) — conservative starting point. Increase if the guard blocks cooling too often; decrease if condensation still occurs.
+
 
 ## 8) Options flow / config flow
 
@@ -300,7 +343,7 @@ Added to `features/hvac_fan_card/const.py` → `FEATURE_DEFINITION["entity_mappi
 ### Backend tests (58 tests)
 
 - **Decision logic:** entering/exiting cooling, heating_retention, hysteresis
-- **Safety:** min_outdoor_temp blocks cooling
+- **Safety:** min_outdoor_temp blocks cooling, dewpoint guard blocks cooling on condensation risk
 - **Stability:** min bypass mode interval prevents command spam
 - **Speed demand:** set during cooling, cleared in idle/heating_retention/disabled
 - **Manual override:** skipped when `is_manual_override_active`, skipped when extras control disabled
@@ -440,3 +483,17 @@ Goal: **one place computes the final actuation plan** (fan speed + bypass mode),
 - The original `_allow_speed_increase` method checked indoor RH against min/max thresholds and blocked speed increases when humidity was out of range.
 - Problem: if humidity_control is not enabled, the min/max RH values have no meaning, and the gate blocked cooling speed increases unnecessarily.
 - Fix: removed per-feature gating entirely. Temp control now always sets its demand during cooling, and the FanSpeedArbiter resolves conflicts.
+
+### 15.5 Dewpoint guard added (condensation protection)
+
+- Added optional `dewpoint_guard_enabled` + `dewpoint_margin_c` settings.
+- When enabled, cooling (bypass open) is blocked if `supply_temp < indoor_dewpoint + margin`.
+- Indoor dewpoint is computed from `indoor_temp` + `indoor_rh` via the Magnus formula.
+- Defaults to off (opt-in) to preserve existing behavior for users who don't need it.
+- Note: the guard depends on `supply_temp` being accurate. If the supply temp sensor is unavailable or not updating, the guard may not trigger correctly.
+
+### 15.6 Select platform not unloaded on integration reload
+
+- `async_unload_entry` was unloading only 4 of 5 platforms (sensor, switch, binary_sensor, number) — `Platform.SELECT` was missing.
+- On reload (options change, manual reload), the select platform was never torn down, causing `ValueError: Config entry ... for ramses_extras.select has already been setup!`.
+- Fix: added `Platform.SELECT` to the `async_unload_platforms` call so unload and setup are symmetric.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ramses_extras"
-version = "0.20.1"
+version = "0.20.2"
 description = "Extra features for Ramses CC integration"
 authors = ["Willem (wimpie70)"]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="ramses_extras",
-    version="0.20.1",
+    version="0.20.2",
     packages=[
         "custom_components.ramses_extras",
         "custom_components.ramses_extras.framework",

--- a/tests/features/temp_control/test_temp_control_automation.py
+++ b/tests/features/temp_control/test_temp_control_automation.py
@@ -31,6 +31,8 @@ def make_settings(**overrides) -> TempControlSettings:
         "min_outdoor_temp": 10.0,
         "min_bypass_mode_interval_seconds": 180,
         "default_desired_speed": "high",
+        "dewpoint_guard_enabled": False,
+        "dewpoint_margin_c": 1.0,
     }
     defaults.update(overrides)
     return TempControlSettings(**defaults)

--- a/tests/features/temp_control/test_temp_control_automation_coverage.py
+++ b/tests/features/temp_control/test_temp_control_automation_coverage.py
@@ -39,6 +39,8 @@ def make_settings(**overrides) -> TempControlSettings:
         "min_outdoor_temp": 10.0,
         "min_bypass_mode_interval_seconds": 180,
         "default_desired_speed": "high",
+        "dewpoint_guard_enabled": False,
+        "dewpoint_margin_c": 1.0,
     }
     defaults.update(overrides)
     return TempControlSettings(**defaults)

--- a/tests/features/temp_control/test_temp_control_config.py
+++ b/tests/features/temp_control/test_temp_control_config.py
@@ -31,6 +31,8 @@ class TestTempControlConfig:
         assert settings.cooling_delta_deactivate == 0.5
         assert settings.min_outdoor_temp == 10.0
         assert settings.min_bypass_mode_interval_seconds == 180
+        assert settings.dewpoint_guard_enabled is False
+        assert settings.dewpoint_margin_c == 1.0
         assert settings.default_desired_speed == "high"
 
     def test_get_settings_from_options(self):
@@ -46,6 +48,8 @@ class TestTempControlConfig:
                         "min_outdoor_temp": 5.0,
                         "min_bypass_mode_interval_seconds": 300,
                         "default_desired_speed": "medium",
+                        "dewpoint_guard_enabled": True,
+                        "dewpoint_margin_c": 2.0,
                     }
                 }
             }
@@ -59,6 +63,8 @@ class TestTempControlConfig:
         assert settings.cooling_delta_deactivate == 1.5
         assert settings.min_outdoor_temp == 5.0
         assert settings.min_bypass_mode_interval_seconds == 300
+        assert settings.dewpoint_guard_enabled is True
+        assert settings.dewpoint_margin_c == 2.0
         assert settings.default_desired_speed == "medium"
 
     def test_get_settings_from_legacy_section(self):

--- a/tests/features/temp_control/test_temp_control_config_flow.py
+++ b/tests/features/temp_control/test_temp_control_config_flow.py
@@ -58,12 +58,15 @@ class TestGetSectionDefaults:
         assert defaults["min_outdoor_temp"] == 10.0
         assert defaults["min_bypass_mode_interval_seconds"] == 180
         assert defaults["default_desired_speed"] == "high"
+        assert defaults["dewpoint_guard_enabled"] is False
+        assert defaults["dewpoint_margin_c"] == 1.0
 
     def test_defaults_from_legacy_store(self, mock_flow):
         mock_flow._config_entry.options = {
             "temp_control": {
                 "comfort_delta_activate": 2.0,
                 "default_desired_speed": "low",
+                "dewpoint_guard_enabled": True,
             }
         }
 
@@ -71,6 +74,7 @@ class TestGetSectionDefaults:
 
         assert defaults["comfort_delta_activate"] == 2.0
         assert defaults["default_desired_speed"] == "low"
+        assert defaults["dewpoint_guard_enabled"] is True
 
     def test_defaults_from_canonical_store(self, mock_flow):
         mock_flow._config_entry.options = {
@@ -79,6 +83,7 @@ class TestGetSectionDefaults:
                     "temp_control": {
                         "min_outdoor_temp": 5.0,
                         "min_bypass_mode_interval_seconds": 300,
+                        "dewpoint_margin_c": 2.5,
                     }
                 }
             }
@@ -88,6 +93,7 @@ class TestGetSectionDefaults:
 
         assert defaults["min_outdoor_temp"] == 5.0
         assert defaults["min_bypass_mode_interval_seconds"] == 300
+        assert defaults["dewpoint_margin_c"] == 2.5
 
 
 class TestPersistTempControlSettings:


### PR DESCRIPTION
Condensation protection: do we need it?

With bypass open, the unit behaves more like a normal ventilator (no heat recovery), so you won’t create “coil condensation” like an AC would.
The realistic condensation risk is: cold supply air (or cold internal surfaces/ducts) + humid indoor air ⇒ condensation on cold surfaces (especially if ducts are poorly insulated).
So rename it to: “dew point guard” rather than “condensation protection”.

If you want a safety net, the most practical rule during cooling is something like:

don’t force bypass open if outdoor_temp is below (indoor dew point + margin), or if indoor RH is already high.
Good news: the temp_control feature already has mappings for indoor RH + min/max RH numbers (see TEMP_CONTROL const mappings), but currently its decision logic is mostly temperature-based. const.py:99-114 automation.py:692-708

We can implement this as an optional setting in temp_control (defaults off), e.g.:

dewpoint_guard_enabled: true/false
dewpoint_margin_c: 1.0