### PR TITLE
fix arbiter

### DIFF
--- a/custom_components/ramses_extras/features/humidity_control/automation.py
+++ b/custom_components/ramses_extras/features/humidity_control/automation.py
@@ -821,7 +821,15 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
                 # Activate dehumidification: set fan HIGH, binary sensor ON
                 await self._activate_dehumidification(device_id, decision)
             elif decision["action"] == "stop":
-                await self._set_fan_low_and_binary_off(device_id, decision)
+                role = decision.get("humidity_role", "neutral")
+                if role == "veto":
+                    # Ventilating would make humidity worse — veto other
+                    # features' ventilation demands.
+                    await self._set_fan_veto_and_binary_off(device_id, decision)
+                else:
+                    # Neutral: humidity is fine, step aside and let other
+                    # features (temp_control, co2_control) decide fan speed.
+                    await self._clear_demand_and_binary_off(device_id, decision)
 
             # Update indicator based on decision
             await self._update_automation_status(device_id, decision)
@@ -1018,12 +1026,18 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
             },
             "confidence": 0.0,
             "control_mode": "idle",
+            # humidity_role determines how the arbiter treats this decision:
+            #  "demand"  – wants ventilation (dehumidify)
+            #  "veto"    – ventilating would make humidity worse, block others
+            #  "neutral" – humidity is fine, let other features decide
+            "humidity_role": "neutral",
         }
 
         # PRIORITY 1: High humidity check (relative humidity threshold) - ORIGINAL LOGIC
         if indoor_rh > max_humidity:
             if indoor_abs > outdoor_abs + offset:  # ORIGINAL COMPARISON
                 decision["action"] = "dehumidify"
+                decision["humidity_role"] = "demand"
                 decision["reasoning"].append(
                     f"High indoor RH: {indoor_rh:.1f}% > {max_humidity:.1f}% "
                     f"with indoor abs ({indoor_abs:.2f}) > outdoor abs "
@@ -1031,8 +1045,21 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
                 )
                 decision["confidence"] = 0.9
                 decision["control_mode"] = "balance"
-            else:
+            elif abs(indoor_abs - outdoor_abs) <= offset:
+                # About equal — ventilating won't help but won't hurt much.
+                # Step aside and let temp_control / co2_control decide.
                 decision["action"] = "stop"
+                decision["humidity_role"] = "neutral"
+                decision["reasoning"].append(
+                    f"High indoor RH: {indoor_rh:.1f}% > {max_humidity:.1f}% "
+                    f"but indoor abs ({indoor_abs:.2f}) ~= outdoor abs "
+                    f"({outdoor_abs:.2f}) (within offset {offset:.2f})"
+                )
+                decision["confidence"] = 0.6
+            else:
+                # Outside is significantly wetter — veto ventilation.
+                decision["action"] = "stop"
+                decision["humidity_role"] = "veto"
                 decision["reasoning"].append(
                     f"High indoor RH: {indoor_rh:.1f}% > {max_humidity:.1f}% "
                     f"but indoor abs ({indoor_abs:.2f}) <= outdoor abs "
@@ -1044,6 +1071,7 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
         elif indoor_rh < min_humidity:
             if indoor_abs < outdoor_abs - offset:  # ORIGINAL COMPARISON
                 decision["action"] = "dehumidify"  # Bring in humid air
+                decision["humidity_role"] = "demand"
                 decision["reasoning"].append(
                     f"Low indoor RH: {indoor_rh:.1f}% < {min_humidity:.1f}% "
                     f"with indoor abs ({indoor_abs:.2f}) < outdoor abs "
@@ -1051,8 +1079,20 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
                 )
                 decision["confidence"] = 0.8
                 decision["control_mode"] = "balance"
-            else:
+            elif abs(indoor_abs - outdoor_abs) <= offset:
+                # About equal — ventilating won't change much. Step aside.
                 decision["action"] = "stop"
+                decision["humidity_role"] = "neutral"
+                decision["reasoning"].append(
+                    f"Low indoor RH: {indoor_rh:.1f}% < {min_humidity:.1f}% "
+                    f"but indoor abs ({indoor_abs:.2f}) ~= outdoor abs "
+                    f"({outdoor_abs:.2f}) (within offset {offset:.2f})"
+                )
+                decision["confidence"] = 0.7
+            else:
+                # Outside is significantly drier — veto ventilation.
+                decision["action"] = "stop"
+                decision["humidity_role"] = "veto"
                 decision["reasoning"].append(
                     f"Low indoor RH: {indoor_rh:.1f}% < {min_humidity:.1f}% "
                     f"but indoor abs ({indoor_abs:.2f}) >= outdoor abs "
@@ -1063,6 +1103,7 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
         # PRIORITY 3: In acceptable range - Stay at normal speed
         else:
             decision["action"] = "stop"
+            decision["humidity_role"] = "neutral"
             decision["reasoning"].append(
                 f"Humidity in acceptable range (RH: {indoor_rh:.1f}%, "
                 f"range: {min_humidity:.1f}% - {max_humidity:.1f}%)"
@@ -1218,9 +1259,10 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
         if decision["action"] != prev_action and decision["reasoning"]:
             reasoning = "; ".join(decision["reasoning"])
             _LOGGER.debug(
-                "Decision for %s: %s (conf=%.2f, diff=%.2f, RH=%.1f%%): %s",
+                "Decision for %s: %s/%s (conf=%.2f, diff=%.2f, RH=%.1f%%): %s",
                 device_id,
                 decision["action"],
+                decision.get("humidity_role", "?"),
                 decision["confidence"],
                 decision["values"]["adjusted_diff"],
                 indoor_rh,
@@ -1433,6 +1475,92 @@ class HumidityAutomationManager(ExtrasBaseAutomation):
 
         except Exception as e:
             _LOGGER.error("Failed to set fan to auto mode: %s", e)
+
+    async def _set_fan_veto_and_binary_off(
+        self, device_id: str, decision: dict[str, Any]
+    ) -> None:
+        """Veto ventilation: block other features from ventilating.
+
+        Used when ventilating would make humidity worse (e.g. outside is
+        wetter than inside while indoor RH is already high).
+        Sets a veto demand with high priority so the arbiter overrides
+        any temp_control / co2_control ventilation requests.
+
+        :param device_id: Device identifier
+        :param decision: Decision information
+        """
+        try:
+            was_dehumidify_active = self._dehumidify_active
+            success = await self.fan_speed_arbiter.async_set_demand(
+                device_id,
+                feature_id=self.feature_id,
+                source_id="humidity_control",
+                requested_speed="fan_low",
+                priority=100,
+                reason="humidity_veto",
+                is_veto=True,
+                metadata=decision,
+            )
+            if not success:
+                _LOGGER.warning(
+                    "Failed to set fan veto for device %s",
+                    device_id,
+                )
+
+            self._dehumidify_active = False
+            if decision.get("control_mode") != "spike_boost":
+                self._clear_active_area_spike(device_id)
+                self._clear_active_indoor_spike(device_id)
+
+            if was_dehumidify_active:
+                reasoning = "; ".join(decision["reasoning"])
+                _LOGGER.info(
+                    "Humidity veto (blocking ventilation): %s",
+                    reasoning,
+                )
+
+        except Exception as e:
+            _LOGGER.error("Failed to set fan veto: %s", e)
+
+    async def _clear_demand_and_binary_off(
+        self, device_id: str, decision: dict[str, Any]
+    ) -> None:
+        """Neutral: clear humidity demand and let other features decide.
+
+        Used when humidity is within range or about equal between inside
+        and outside.  Does not set any fan speed — steps aside so
+        temp_control / co2_control can decide.
+
+        :param device_id: Device identifier
+        :param decision: Decision information
+        """
+        try:
+            was_dehumidify_active = self._dehumidify_active
+            success = await self.fan_speed_arbiter.async_clear_demand(
+                device_id,
+                feature_id=self.feature_id,
+                source_id="humidity_control",
+            )
+            if not success:
+                _LOGGER.warning(
+                    "Failed to clear humidity demand for device %s",
+                    device_id,
+                )
+
+            self._dehumidify_active = False
+            if decision.get("control_mode") != "spike_boost":
+                self._clear_active_area_spike(device_id)
+                self._clear_active_indoor_spike(device_id)
+
+            if was_dehumidify_active:
+                reasoning = "; ".join(decision["reasoning"])
+                _LOGGER.info(
+                    "Humidity neutral (stepping aside): %s",
+                    reasoning,
+                )
+
+        except Exception as e:
+            _LOGGER.error("Failed to clear humidity demand: %s", e)
 
     async def _stop_dehumidification_without_switch_change(
         self, device_id: str

--- a/custom_components/ramses_extras/features/temp_control/automation.py
+++ b/custom_components/ramses_extras/features/temp_control/automation.py
@@ -436,8 +436,31 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
             dewpoint = self._calc_dewpoint_c(indoor_temp, indoor_rh)
             margin = float(getattr(settings, "dewpoint_margin_c", 1.0))
             if dewpoint is not None and supply_temp < dewpoint + margin:
+                _LOGGER.debug(
+                    "Temp_control for %s: dewpoint guard cancelling cooling "
+                    "(supply=%.1f < dewpoint+margin=%.1f+%.1f=%.1f)",
+                    device_id,
+                    supply_temp,
+                    dewpoint,
+                    margin,
+                    dewpoint + margin,
+                )
                 desired_mode = "idle"
                 await self._clear_all_zone_demands(device_id)
+
+        _LOGGER.debug(
+            "Decision for %s: mode=%s (prev=%s, indoor=%.1f, outdoor=%.1f, "
+            "supply=%.1f, comfort=%.1f, RH=%.1f%%, areas=%d)",
+            device_id,
+            desired_mode,
+            prev_mode,
+            indoor_temp,
+            outdoor_temp,
+            supply_temp,
+            comfort_temp,
+            indoor_rh,
+            len(area_results),
+        )
 
         # Enforce minimum interval between bypass mode changes
         last_change = self._last_bypass_change.get(device_id, 0.0)
@@ -445,6 +468,13 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
             desired_mode != prev_mode
             and (now - last_change) < settings.min_bypass_mode_interval_seconds
         ):
+            _LOGGER.debug(
+                "Temp_control for %s: suppressing %s->%s (min interval %.0fs)",
+                device_id,
+                prev_mode,
+                desired_mode,
+                settings.min_bypass_mode_interval_seconds,
+            )
             desired_mode = prev_mode
 
         bypass_cmd = {
@@ -465,6 +495,13 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
         dedup_expired = (now - last_cmd_time) >= bypass_dedup_seconds
 
         if desired_mode != prev_mode and (command_changed or dedup_expired):
+            _LOGGER.debug(
+                "Temp_control for %s: sending bypass %s (%s->%s)",
+                device_id,
+                bypass_cmd,
+                prev_mode,
+                desired_mode,
+            )
             await self.ramses_commands.send_command(device_id, bypass_cmd)
             self._last_bypass_change[device_id] = now
             self._last_bypass_command[device_id] = bypass_cmd
@@ -477,6 +514,11 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
         effective_speed_note = "no_speed_change"
         if desired_mode == "cooling":
             desired_speed = self._get_desired_speed_option(device_id)
+            _LOGGER.debug(
+                "Temp_control for %s: requesting fan %s (cooling mode)",
+                device_id,
+                desired_speed,
+            )
             await self.fan_speed_arbiter.async_set_demand(
                 device_id,
                 feature_id=self.feature_id,

--- a/custom_components/ramses_extras/framework/helpers/fan_speed_arbiter.py
+++ b/custom_components/ramses_extras/framework/helpers/fan_speed_arbiter.py
@@ -44,13 +44,20 @@ _SPEED_NORMALIZATION = {
 
 @dataclass(slots=True)
 class FanSpeedDemand:
-    """A single feature demand for a device fan speed."""
+    """A single feature demand for a device fan speed.
+
+    A demand can be a normal request (is_veto=False) or a veto
+    (is_veto=True).  A veto blocks ventilation from other features
+    and forces the fan to the requested (low) speed, regardless of
+    other features' speed requests.
+    """
 
     feature_id: str
     source_id: str
     requested_speed: str
     priority: int = 0
     reason: str = ""
+    is_veto: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
@@ -185,6 +192,7 @@ class FanSpeedArbiter:
         requested_speed: str | int,
         priority: int = 0,
         reason: str = "",
+        is_veto: bool = False,
         metadata: dict[str, Any] | None = None,
     ) -> None:
         normalized_device_id = self._normalize_device_id(device_id)
@@ -195,6 +203,7 @@ class FanSpeedArbiter:
             requested_speed=command_name,
             priority=priority,
             reason=reason,
+            is_veto=is_veto,
             metadata=metadata or {},
         )
         device_demands = self._demands.setdefault(normalized_device_id, {})
@@ -264,6 +273,7 @@ class FanSpeedArbiter:
         requested_speed: str | int,
         priority: int = 0,
         reason: str = "",
+        is_veto: bool = False,
         metadata: dict[str, Any] | None = None,
     ) -> bool:
         """Create or update a feature demand and apply the resolved command."""
@@ -274,6 +284,7 @@ class FanSpeedArbiter:
             requested_speed=requested_speed,
             priority=priority,
             reason=reason,
+            is_veto=is_veto,
             metadata=metadata,
         )
         return await self.async_commit_state(device_id)
@@ -339,6 +350,26 @@ class FanSpeedArbiter:
                 active_demands=active_demands,
             )
 
+        # Veto demands: a feature that says "don't ventilate" overrides
+        # all normal speed demands.  Among multiple vetoes, the one with
+        # the highest priority wins (most urgent reason to stop).
+        veto_demands = [d for d in active_demands if d.is_veto]
+        if veto_demands:
+            winning_demand = max(
+                veto_demands,
+                key=lambda demand: (
+                    demand.priority,
+                    demand.updated_at,
+                ),
+            )
+            return ResolvedFanSpeed(
+                device_id=normalized_device_id,
+                command_name=winning_demand.requested_speed,
+                winning_demand=winning_demand,
+                active_demands=active_demands,
+            )
+
+        # No vetoes: pick the highest speed among normal demands.
         winning_demand = max(
             active_demands,
             key=lambda demand: (

--- a/tests/features/humidity_control/test_humidity_automation_mgr.py
+++ b/tests/features/humidity_control/test_humidity_automation_mgr.py
@@ -104,10 +104,11 @@ class TestHumidityAutomationManager:
 
     @patch.object(HumidityAutomationManager, "_evaluate_humidity_conditions")
     @patch.object(HumidityAutomationManager, "_activate_dehumidification")
-    @patch.object(HumidityAutomationManager, "_set_fan_low_and_binary_off")
+    @patch.object(HumidityAutomationManager, "_clear_demand_and_binary_off")
+    @patch.object(HumidityAutomationManager, "_set_fan_veto_and_binary_off")
     @patch.object(HumidityAutomationManager, "_update_automation_status")
     async def test_process_automation_logic_stop(
-        self, mock_update, mock_stop, mock_activate, mock_evaluate
+        self, mock_update, mock_veto, mock_clear, mock_activate, mock_evaluate
     ):
         """Test processing automation logic when dehumidification should stop."""
         device_id = "32_123456"
@@ -121,20 +122,27 @@ class TestHumidityAutomationManager:
             "dehumidify": True,
         }
 
-        decision = {"action": "stop", "reasoning": ["Test"], "confidence": 1.0}
+        decision = {
+            "action": "stop",
+            "reasoning": ["Test"],
+            "confidence": 1.0,
+            "humidity_role": "neutral",
+        }
         mock_evaluate.return_value = decision
 
         await self.manager._process_automation_logic(device_id, entity_states)
 
-        mock_stop.assert_called_once_with(device_id, decision)
+        mock_clear.assert_called_once_with(device_id, decision)
+        mock_veto.assert_not_called()
         mock_update.assert_called_once_with(device_id, decision)
 
     @patch.object(HumidityAutomationManager, "_evaluate_humidity_conditions")
     @patch.object(HumidityAutomationManager, "_activate_dehumidification")
-    @patch.object(HumidityAutomationManager, "_set_fan_low_and_binary_off")
+    @patch.object(HumidityAutomationManager, "_clear_demand_and_binary_off")
+    @patch.object(HumidityAutomationManager, "_set_fan_veto_and_binary_off")
     @patch.object(HumidityAutomationManager, "_update_automation_status")
     async def test_process_automation_logic_skips_when_manual_override_active(
-        self, mock_update, mock_stop, mock_activate, mock_evaluate
+        self, mock_update, mock_veto, mock_clear, mock_activate, mock_evaluate
     ):
         """Sticky manual override should short-circuit humidity automation."""
         device_id = "32_123456"
@@ -145,17 +153,19 @@ class TestHumidityAutomationManager:
 
         mock_evaluate.assert_not_called()
         mock_activate.assert_not_called()
-        mock_stop.assert_not_called()
+        mock_clear.assert_not_called()
+        mock_veto.assert_not_called()
         mock_update.assert_not_called()
 
     @patch.object(HumidityAutomationManager, "_evaluate_humidity_conditions")
     @patch.object(HumidityAutomationManager, "_activate_dehumidification")
-    @patch.object(HumidityAutomationManager, "_set_fan_low_and_binary_off")
+    @patch.object(HumidityAutomationManager, "_clear_demand_and_binary_off")
+    @patch.object(HumidityAutomationManager, "_set_fan_veto_and_binary_off")
     @patch.object(HumidityAutomationManager, "_update_automation_status")
     async def test_process_automation_logic_stop_uses_low_balance_demand(
-        self, mock_update, mock_stop, mock_activate, mock_evaluate
+        self, mock_update, mock_veto, mock_clear, mock_activate, mock_evaluate
     ):
-        """Stop decisions should keep humidity's low-speed demand active."""
+        """Neutral stop decisions should clear demand (let other features decide)."""
         device_id = "32_123456"
         entity_states = {
             "indoor_rh": 50.0,
@@ -172,12 +182,14 @@ class TestHumidityAutomationManager:
             "reasoning": ["Humidity in range for balance mode"],
             "confidence": 1.0,
             "control_mode": "balance",
+            "humidity_role": "neutral",
         }
         mock_evaluate.return_value = decision
 
         await self.manager._process_automation_logic(device_id, entity_states)
 
-        mock_stop.assert_called_once_with(device_id, decision)
+        mock_clear.assert_called_once_with(device_id, decision)
+        mock_veto.assert_not_called()
         mock_activate.assert_not_called()
         mock_update.assert_called_once_with(device_id, decision)
         assert self.manager._dehumidify_active is False

--- a/tests/features/humidity_control/test_humidity_automation_mgr.py
+++ b/tests/features/humidity_control/test_humidity_automation_mgr.py
@@ -194,6 +194,70 @@ class TestHumidityAutomationManager:
         mock_update.assert_called_once_with(device_id, decision)
         assert self.manager._dehumidify_active is False
 
+    @patch.object(HumidityAutomationManager, "_evaluate_humidity_conditions")
+    @patch.object(HumidityAutomationManager, "_update_automation_status")
+    async def test_process_automation_logic_veto_calls_arbiter_with_is_veto(
+        self, mock_update, mock_evaluate
+    ):
+        """Veto decisions should call async_set_demand with is_veto=True."""
+        device_id = "32_123456"
+        entity_states = {
+            "indoor_rh": 62.0,
+            "indoor_abs": 16.0,
+            "outdoor_abs": 26.0,
+            "min_humidity": 40.0,
+            "max_humidity": 57.0,
+            "offset": 0.2,
+            "dehumidify": True,
+        }
+
+        decision = {
+            "action": "stop",
+            "reasoning": ["High indoor RH but outside wetter"],
+            "confidence": 0.6,
+            "humidity_role": "veto",
+        }
+        mock_evaluate.return_value = decision
+
+        await self.manager._process_automation_logic(device_id, entity_states)
+
+        self.fan_speed_arbiter.async_set_demand.assert_called_once()
+        call_kwargs = self.fan_speed_arbiter.async_set_demand.call_args
+        assert call_kwargs.kwargs.get("is_veto") is True
+        assert call_kwargs.kwargs.get("requested_speed") == "fan_low"
+        assert call_kwargs.kwargs.get("priority") == 100
+        self.fan_speed_arbiter.async_clear_demand.assert_not_called()
+
+    @patch.object(HumidityAutomationManager, "_evaluate_humidity_conditions")
+    @patch.object(HumidityAutomationManager, "_update_automation_status")
+    async def test_process_automation_logic_neutral_clears_demand(
+        self, mock_update, mock_evaluate
+    ):
+        """Neutral decisions should clear the demand, not set a new one."""
+        device_id = "32_123456"
+        entity_states = {
+            "indoor_rh": 50.0,
+            "indoor_abs": 10.0,
+            "outdoor_abs": 10.0,
+            "min_humidity": 40.0,
+            "max_humidity": 60.0,
+            "offset": 0.2,
+            "dehumidify": True,
+        }
+
+        decision = {
+            "action": "stop",
+            "reasoning": ["Humidity in acceptable range"],
+            "confidence": 1.0,
+            "humidity_role": "neutral",
+        }
+        mock_evaluate.return_value = decision
+
+        await self.manager._process_automation_logic(device_id, entity_states)
+
+        self.fan_speed_arbiter.async_clear_demand.assert_called_once()
+        self.fan_speed_arbiter.async_set_demand.assert_not_called()
+
     async def test_process_automation_logic_switch_off(self):
         """Test processing automation logic when switch is off."""
         device_id = "32_123456"
@@ -378,6 +442,106 @@ class TestHumidityAutomationManager:
         )
         assert decision["action"] == "stop"
         assert "acceptable range" in decision["reasoning"][0]
+
+    # --- humidity_role classification tests ---
+
+    async def test_humidity_role_demand_when_high_rh_inside_wetter(self):
+        """High indoor RH + inside wetter than outside → demand (ventilate)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=70.0,
+            indoor_abs=18.0,
+            outdoor_abs=12.0,
+            min_humidity=40.0,
+            max_humidity=60.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "dehumidify"
+        assert decision["humidity_role"] == "demand"
+
+    async def test_humidity_role_veto_when_high_rh_outside_wetter(self):
+        """High indoor RH + outside significantly wetter → veto (block ventilation)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=62.0,
+            indoor_abs=16.0,
+            outdoor_abs=26.0,
+            min_humidity=40.0,
+            max_humidity=57.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "stop"
+        assert decision["humidity_role"] == "veto"
+
+    async def test_humidity_role_neutral_when_high_rh_about_equal(self):
+        """High indoor RH + abs about equal → neutral (step aside)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=62.0,
+            indoor_abs=16.0,
+            outdoor_abs=16.1,
+            min_humidity=40.0,
+            max_humidity=57.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "stop"
+        assert decision["humidity_role"] == "neutral"
+
+    async def test_humidity_role_demand_when_low_rh_outside_wetter(self):
+        """Low indoor RH + outside wetter → demand (ventilate to humidify)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=30.0,
+            indoor_abs=5.0,
+            outdoor_abs=10.0,
+            min_humidity=40.0,
+            max_humidity=60.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "dehumidify"
+        assert decision["humidity_role"] == "demand"
+
+    async def test_humidity_role_veto_when_low_rh_outside_drier(self):
+        """Low indoor RH + outside significantly drier → veto (block ventilation)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=30.0,
+            indoor_abs=8.0,
+            outdoor_abs=5.0,
+            min_humidity=40.0,
+            max_humidity=60.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "stop"
+        assert decision["humidity_role"] == "veto"
+
+    async def test_humidity_role_neutral_when_low_rh_about_equal(self):
+        """Low indoor RH + abs about equal → neutral (step aside)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=30.0,
+            indoor_abs=8.0,
+            outdoor_abs=8.1,
+            min_humidity=40.0,
+            max_humidity=60.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "stop"
+        assert decision["humidity_role"] == "neutral"
+
+    async def test_humidity_role_neutral_when_rh_in_range(self):
+        """RH within range → neutral (step aside)."""
+        decision = await self.manager._evaluate_humidity_conditions(
+            device_id="test",
+            indoor_rh=50.0,
+            indoor_abs=10.0,
+            outdoor_abs=20.0,
+            min_humidity=40.0,
+            max_humidity=60.0,
+            offset=0.2,
+        )
+        assert decision["action"] == "stop"
+        assert decision["humidity_role"] == "neutral"
 
     async def test_evaluate_humidity_conditions_area_spike_detected(self):
         """Area spike should trigger spike_boost dehumidification."""

--- a/tests/framework/helpers/test_fan_speed_arbiter.py
+++ b/tests/framework/helpers/test_fan_speed_arbiter.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.ramses_extras.framework.helpers.fan_speed_arbiter import (
     FanSpeedArbiter,
+    FanSpeedDemand,
     get_fan_speed_arbiter,
 )
 
@@ -428,3 +429,122 @@ def test_get_fan_speed_arbiter_uses_fallback_attribute_for_mock_hass():
         second = get_fan_speed_arbiter(mock_hass)
 
     assert first is second
+
+
+def test_veto_overrides_higher_speed_demand(arbiter):
+    """A veto demand should win over a higher-speed normal demand."""
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_low",
+                priority=100,
+                reason="humidity_veto",
+                is_veto=True,
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+
+    assert resolved.command_name == "fan_low"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.is_veto is True
+    assert resolved.winning_demand.feature_id == "humidity_control"
+
+
+def test_veto_with_lower_priority_still_wins(arbiter):
+    """A veto with lower priority than another veto still wins on priority."""
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_low",
+                priority=50,
+                reason="humidity_veto",
+                is_veto=True,
+            ),
+            ("co2_control", "co2_control"): FanSpeedDemand(
+                feature_id="co2_control",
+                source_id="co2_control",
+                requested_speed="fan_low",
+                priority=200,
+                reason="co2_veto",
+                is_veto=True,
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+
+    # Higher-priority veto wins among vetoes
+    assert resolved.command_name == "fan_low"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.is_veto is True
+    assert resolved.winning_demand.feature_id == "co2_control"
+
+
+def test_no_veto_uses_highest_speed(arbiter):
+    """Without vetoes, the highest speed demand should still win."""
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_low",
+                priority=5,
+                reason="humidity_balance_idle",
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+
+    assert resolved.command_name == "fan_high"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.feature_id == "temp_control"
+
+
+def test_neutral_clears_demand_lets_others_win(arbiter):
+    """When humidity clears its demand (neutral), temp_control should win."""
+    # Only temp_control has a demand — humidity cleared its demand
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+
+    assert resolved.command_name == "fan_high"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.feature_id == "temp_control"

--- a/tests/framework/helpers/test_fan_speed_arbiter.py
+++ b/tests/framework/helpers/test_fan_speed_arbiter.py
@@ -548,3 +548,187 @@ def test_neutral_clears_demand_lets_others_win(arbiter):
     assert resolved.command_name == "fan_high"
     assert resolved.winning_demand is not None
     assert resolved.winning_demand.feature_id == "temp_control"
+
+
+# --- Integration-style tests: simulate full humidity + temp_control flow ---
+
+
+def test_integration_humidity_veto_blocks_temp_cooling(arbiter):
+    """Simulate: temp_control wants cooling (fan_high) but humidity vetoes.
+
+    This is the scenario from the bug report: humidity says 'stop' because
+    outside is wetter, but temp_control wants to cool.  The veto should win.
+    """
+    # temp_control sets a fan_high demand (cooling mode)
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            # humidity_control vetoes because outside is wetter
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_low",
+                priority=100,
+                reason="humidity_veto",
+                is_veto=True,
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+
+    # Veto wins — fan should be low, not high
+    assert resolved.command_name == "fan_low"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.is_veto is True
+    assert resolved.winning_demand.feature_id == "humidity_control"
+    # Both demands are still active (veto doesn't remove temp_control's demand)
+    assert len(resolved.active_demands) == 2
+
+
+def test_integration_humidity_neutral_lets_temp_cool(arbiter):
+    """Simulate: humidity is neutral (steps aside), temp_control cools.
+
+    Humidity clears its demand.  Only temp_control has a demand.
+    temp_control's fan_high should win.
+    """
+    # humidity_control cleared its demand (neutral) — only temp_control remains
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32:123456")
+
+    assert resolved.command_name == "fan_high"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.feature_id == "temp_control"
+    assert not resolved.winning_demand.is_veto
+
+
+def test_integration_humidity_demand_and_temp_cool_both_want_high(arbiter):
+    """Simulate: both humidity and temp want ventilation — no conflict."""
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="humidity_dehumidify",
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32:123456")
+
+    # Both want fan_high — highest speed wins (tie broken by priority/timestamp)
+    assert resolved.command_name == "fan_high"
+    assert resolved.winning_demand is not None
+    assert not resolved.winning_demand.is_veto
+
+
+def test_integration_co2_veto_overrides_temp_and_humidity(arbiter):
+    """Simulate: CO2 vetoes, temp and humidity both want ventilation."""
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="humidity_dehumidify",
+            ),
+            ("co2_control", "co2_control"): FanSpeedDemand(
+                feature_id="co2_control",
+                source_id="co2_control",
+                requested_speed="fan_low",
+                priority=200,
+                reason="co2_veto",
+                is_veto=True,
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+
+    # CO2 veto wins
+    assert resolved.command_name == "fan_low"
+    assert resolved.winning_demand is not None
+    assert resolved.winning_demand.is_veto is True
+    assert resolved.winning_demand.feature_id == "co2_control"
+
+
+def test_integration_humidity_veto_then_clear_lets_temp_resume(arbiter):
+    """Simulate: humidity vetoes, then clears veto — temp_control resumes.
+
+    This verifies that clearing the veto demand allows temp_control's
+    demand to take effect again.
+    """
+    # Step 1: humidity veto blocks temp_control
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+            ("humidity_control", "humidity_control"): FanSpeedDemand(
+                feature_id="humidity_control",
+                source_id="humidity_control",
+                requested_speed="fan_low",
+                priority=100,
+                reason="humidity_veto",
+                is_veto=True,
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+    assert resolved.command_name == "fan_low"
+
+    # Step 2: humidity clears its veto (conditions changed — now neutral)
+    arbiter._demands = {
+        "32:123456": {
+            ("temp_control", "temp_control"): FanSpeedDemand(
+                feature_id="temp_control",
+                source_id="temp_control",
+                requested_speed="fan_high",
+                priority=20,
+                reason="temp_control_cooling",
+            ),
+        }
+    }
+
+    resolved = arbiter.resolve("32_123456")
+    assert resolved.command_name == "fan_high"
+    assert resolved.winning_demand.feature_id == "temp_control"


### PR DESCRIPTION
Problem
The humidity_control automation was sending "Set fan to high speed" commands even when its decision was to stop dehumidification. The log showed "Fan set to LOW mode" but the actual command sent was "Set fan to high speed" — a contradiction.

Root Cause
The FanSpeedArbiter.resolve() picked the highest speed across all features, not the highest priority. So temp_control's fan_high demand (priority 20) always won over humidity_control's fan_low demand (priority 5), regardless of priority values. The humidity "stop" was completely ignored.

Fix — 3 changes
1. Arbiter veto support (fan_speed_arbiter.py)

Added is_veto: bool field to FanSpeedDemand
Updated resolve(): veto demands are evaluated first and override all normal speed demands. Among multiple vetoes, the highest priority wins.
async_set_demand and _set_demand_state now accept is_veto=True
2. Humidity decision: veto vs neutral (humidity_control/automation.py)

Added humidity_role field to the decision dict: "demand", "veto", or "neutral"
Veto (blocks ventilation): indoor RH is high but outside is significantly wetter, or indoor RH is low but outside is significantly drier → ventilating would make humidity worse
Neutral (steps aside): RH within range, OR abs inside ≈ abs outside (within offset, less strict) → humidity is fine, let temp_control/co2_control decide
Demand: wants ventilation (dehumidify)
Added two new methods: _set_fan_veto_and_binary_off (sets veto demand) and _clear_demand_and_binary_off (clears demand, neutral)
The old _set_fan_low_and_binary_off is kept but no longer called
3. temp_control logging (temp_control/automation.py)

Added _LOGGER.debug for mode decisions, dewpoint guard cancellations, bypass commands, and fan speed requests — so you can now see what temp_control is doing in the logs
Test results
All 179 humidity + arbiter tests pass
ruff: all checks passed
mypy: no issues found
4 new arbiter tests added: test_veto_overrides_higher_speed_demand, test_veto_with_lower_priority_still_wins, test_no_veto_uses_highest_speed, test_neutral_clears_demand_lets_others_win


fix for issue #93 