### PR TITLE
fix: temp_control bypass safety net false-positives and stuck bypass

### DIFF
--- a/custom_components/ramses_extras/features/temp_control/automation.py
+++ b/custom_components/ramses_extras/features/temp_control/automation.py
@@ -130,6 +130,12 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
         for device_id in list(self._mode):
             await self._clear_speed_demand(device_id)
             await self._clear_all_zone_demands(device_id)
+            # Release the bypass back to the device's own control so it
+            # is not left in a forced open/close state when temp_control
+            # stops.  Only send if we were actively forcing a bypass state
+            # (cooling/heating_retention); in idle we already sent auto.
+            if self._mode.get(device_id) in {"cooling", "heating_retention"}:
+                await self._release_bypass(device_id)
 
         await super().stop()
 
@@ -199,23 +205,38 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
                 switch_id = f"switch.temp_control_{device_id.replace(':', '_')}"
                 switch_state = self.hass.states.get(switch_id)
                 if switch_state and switch_state.state == "on":
-                    # Was this change caused by our own command?
-                    last_cmd_time = self._last_bypass_command_time.get(device_id, 0.0)
-                    now = _time.time()
-                    # Allow a 10s window for our command to take effect
-                    if now - last_cmd_time > 10.0:
-                        _LOGGER.info(
-                            "External bypass change detected for %s "
-                            "(no recent temp_control command); "
-                            "turning temp_control off",
-                            device_id,
+                    # Only treat bypass changes as a manual override when
+                    # temp_control is actively forcing a bypass state
+                    # (cooling = bypass open, heating_retention = bypass
+                    # close).  In "idle" mode we sent fan_bypass_auto, so
+                    # the FAN device is free to move the bypass damper on
+                    # its own — those changes are expected, not manual
+                    # overrides, and must not disable temp_control.
+                    # This also covers bypass movements induced by other
+                    # features (e.g. humidity_control veto forcing fan_low)
+                    # when the device repositions the damper in response.
+                    current_mode = self._mode.get(device_id, "idle")
+                    if current_mode in {"cooling", "heating_retention"}:
+                        # Was this change caused by our own command?
+                        last_cmd_time = self._last_bypass_command_time.get(
+                            device_id, 0.0
                         )
-                        await self.hass.services.async_call(
-                            "switch",
-                            "turn_off",
-                            {"entity_id": switch_id},
-                        )
-                        return
+                        now = _time.time()
+                        # Allow a 10s window for our command to take effect
+                        if now - last_cmd_time > 10.0:
+                            _LOGGER.info(
+                                "External bypass change detected for %s "
+                                "(mode=%s, no recent temp_control command); "
+                                "turning temp_control off",
+                                device_id,
+                                current_mode,
+                            )
+                            await self.hass.services.async_call(
+                                "switch",
+                                "turn_off",
+                                {"entity_id": switch_id},
+                            )
+                            return
 
         # Bypass debounce for user-initiated switch toggles — these should
         # be processed immediately, not delayed by sensor-fluctuation debounce.
@@ -576,15 +597,38 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
     async def _handle_disabled(self, device_id: str, reason: str) -> None:
         await self._clear_speed_demand(device_id)
         await self._clear_all_zone_demands(device_id)
+        prev_mode = self._mode.get(device_id)
         self._mode[device_id] = "disabled"
         # Reset bypass change timestamp so the first mode change after
         # re-enabling is not blocked by the min-interval guard.
         self._last_bypass_change.pop(device_id, None)
         self._last_bypass_command.pop(device_id, None)
 
+        # Release the bypass back to the device's own control so it is
+        # not left in a forced open/close state.  Only send if we were
+        # actively forcing a bypass state; in idle we already sent auto,
+        # and on a fresh startup (no prev_mode) the device is already
+        # autonomous.
+        if prev_mode in {"cooling", "heating_retention"}:
+            await self._release_bypass(device_id)
+
         attrs = {"mode": "disabled", "reason": reason}
         self._set_active_indicator(device_id, False, attrs)
         self._set_status_sensor(device_id, "disabled", attrs)
+
+    async def _release_bypass(self, device_id: str) -> None:
+        """Send fan_bypass_auto so the device resumes autonomous bypass control.
+
+        Used when temp_control stops or is disabled while it was actively
+        forcing a bypass state (cooling/heating_retention).  Without this
+        the bypass damper is left in the last forced position.
+        """
+        try:
+            await self.ramses_commands.send_command(device_id, "fan_bypass_auto")
+        except Exception as err:
+            _LOGGER.warning(
+                "Failed to release bypass to auto for %s: %s", device_id, err
+            )
 
     async def _clear_speed_demand(self, device_id: str) -> None:
         try:

--- a/tests/features/temp_control/test_temp_control_automation.py
+++ b/tests/features/temp_control/test_temp_control_automation.py
@@ -531,6 +531,9 @@ class TestTempControlBypassSafetyNet:
 
         # No recent bypass command from temp_control (old timestamp)
         automation_manager._last_bypass_command_time["32:153289"] = time.time() - 60
+        # Safety net only fires when temp_control is actively forcing a
+        # bypass state (cooling/heating_retention), not in idle.
+        automation_manager._mode["32:153289"] = "cooling"
 
         old_state = MagicMock()
         new_state = MagicMock()
@@ -965,3 +968,167 @@ class TestTempControlPerAreaEvaluation:
 
         # Cooling should win
         assert automation_manager._mode["32:153289"] == "cooling"
+
+
+class TestTempControlBypassFlowProdScenario:
+    """End-to-end flow tests simulating the prod HA scenario.
+
+    Reproduces: temp_control in idle → humidity_control veto forces fan_low
+    via the arbiter → FAN device repositions the bypass damper → the bypass
+    position entity changes → the safety net must NOT turn temp_control off.
+
+    Also covers: temp_control disabled while forcing bypass → fan_bypass_auto
+    is sent so the device resumes autonomous bypass control.
+    """
+
+    @pytest.mark.asyncio
+    async def test_idle_bypass_change_from_humidity_veto_does_not_disable(
+        self, automation_manager
+    ):
+        """Prod scenario: idle mode + humidity veto → bypass moves → no disable.
+
+        1. temp_control evaluates to idle (indoor near comfort, no cooling/
+           heating needed) and sends fan_bypass_auto.
+        2. humidity_control sets a veto (fan_low) via the arbiter because
+           outside is wetter than inside.
+        3. The FAN device, now running at low speed with bypass in auto,
+           repositions the damper → binary_sensor.*_bypass_position changes.
+        4. The safety net must NOT turn temp_control off, because in idle
+           mode the bypass is in the device's hands.
+        """
+        import time
+
+        hass = automation_manager.hass
+
+        # Step 1: temp_control is on and in idle mode (sent fan_bypass_auto)
+        switch_state = MagicMock()
+        switch_state.state = "on"
+        hass.states.get = MagicMock(return_value=switch_state)
+        hass.services.async_call = AsyncMock()
+        automation_manager._mode["32:153289"] = "idle"
+        # Timestamp is stale — simulates steady state where no bypass
+        # command was sent for a while (the original false-positive trigger)
+        automation_manager._last_bypass_command_time["32:153289"] = time.time() - 120
+
+        # Step 3: bypass position entity changes (device repositioned damper)
+        old_state = MagicMock(state="open")
+        new_state = MagicMock(state="closed")
+
+        with patch.object(
+            type(automation_manager).__mro__[1],
+            "_async_handle_state_change",
+            new_callable=AsyncMock,
+        ) as mock_super:
+            await automation_manager._async_handle_state_change(
+                "binary_sensor.32_153289_bypass_position",
+                old_state,
+                new_state,
+            )
+
+        # Safety net must NOT turn off the switch
+        hass.services.async_call.assert_not_called()
+        # Mode must remain idle (not changed to disabled)
+        assert automation_manager._mode["32:153289"] == "idle"
+        # State change passes through to normal handler
+        mock_super.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cooling_bypass_external_change_disables_temp_control(
+        self, automation_manager
+    ):
+        """Contrast: in cooling mode (forcing bypass open), an external bypass
+        change IS a real manual override → temp_control is disabled.
+        """
+        import time
+
+        hass = automation_manager.hass
+        switch_state = MagicMock()
+        switch_state.state = "on"
+        hass.states.get = MagicMock(return_value=switch_state)
+        hass.services.async_call = AsyncMock()
+        automation_manager._mode["32:153289"] = "cooling"
+        automation_manager._last_bypass_command_time["32:153289"] = time.time() - 120
+
+        old_state = MagicMock(state="open")
+        new_state = MagicMock(state="closed")
+
+        await automation_manager._async_handle_state_change(
+            "binary_sensor.32_153289_bypass_position",
+            old_state,
+            new_state,
+        )
+
+        hass.services.async_call.assert_called_once_with(
+            "switch",
+            "turn_off",
+            {"entity_id": "switch.temp_control_32_153289"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_disabled_releases_bypass_when_forcing(
+        self, automation_manager
+    ):
+        """_handle_disabled sends fan_bypass_auto when previously forcing bypass.
+
+        When temp_control was in cooling/heating_retention (forcing a bypass
+        state) and gets disabled, the bypass must be released back to the
+        device's autonomous control.  Without this the damper stays stuck.
+        """
+        automation_manager._mode["32:153289"] = "cooling"
+        automation_manager.ramses_commands.send_command = AsyncMock()
+
+        await automation_manager._handle_disabled("32:153289", reason="disabled")
+
+        # fan_bypass_auto sent to release the damper
+        automation_manager.ramses_commands.send_command.assert_called_once_with(
+            "32:153289", "fan_bypass_auto"
+        )
+        assert automation_manager._mode["32:153289"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_handle_disabled_does_not_release_bypass_in_idle(
+        self, automation_manager
+    ):
+        """_handle_disabled does NOT send fan_bypass_auto when already idle.
+
+        In idle we already sent fan_bypass_auto, so no need to resend on
+        disable (avoids a spurious command).
+        """
+        automation_manager._mode["32:153289"] = "idle"
+        automation_manager.ramses_commands.send_command = AsyncMock()
+
+        await automation_manager._handle_disabled("32:153289", reason="disabled")
+
+        automation_manager.ramses_commands.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_releases_bypass_when_forcing(self, automation_manager):
+        """stop() sends fan_bypass_auto for devices that were forcing bypass."""
+        automation_manager._mode["32:153289"] = "heating_retention"
+        automation_manager.ramses_commands.send_command = AsyncMock()
+        automation_manager._clear_speed_demand = AsyncMock()
+        automation_manager._clear_all_zone_demands = AsyncMock()
+
+        with patch.object(
+            type(automation_manager).__mro__[1], "stop", new_callable=AsyncMock
+        ):
+            await automation_manager.stop()
+
+        automation_manager.ramses_commands.send_command.assert_called_once_with(
+            "32:153289", "fan_bypass_auto"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_does_not_release_bypass_in_idle(self, automation_manager):
+        """stop() does NOT send fan_bypass_auto for idle devices."""
+        automation_manager._mode["32:153289"] = "idle"
+        automation_manager.ramses_commands.send_command = AsyncMock()
+        automation_manager._clear_speed_demand = AsyncMock()
+        automation_manager._clear_all_zone_demands = AsyncMock()
+
+        with patch.object(
+            type(automation_manager).__mro__[1], "stop", new_callable=AsyncMock
+        ):
+            await automation_manager.stop()
+
+        automation_manager.ramses_commands.send_command.assert_not_called()

--- a/tests/features/temp_control/test_temp_control_automation_coverage.py
+++ b/tests/features/temp_control/test_temp_control_automation_coverage.py
@@ -423,7 +423,8 @@ class TestAsyncHandleStateChange:
 
     @pytest.mark.asyncio
     async def test_external_bypass_change_turns_off_switch(self, automation_manager):
-        """External bypass change (no recent command) → turn off switch."""
+        """External bypass change while forcing bypass (cooling) → turn off switch."""
+        automation_manager._mode["32:153289"] = "cooling"
         automation_manager._last_bypass_command_time["32:153289"] = 0.0
         automation_manager.hass.states.get = MagicMock(
             return_value=MagicMock(state="on")
@@ -444,6 +445,34 @@ class TestAsyncHandleStateChange:
                 {"entity_id": "switch.temp_control_32_153289"},
             )
             mock_super.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_external_bypass_change_in_idle_does_not_turn_off(
+        self, automation_manager
+    ):
+        """Bypass change in idle mode (bypass auto) → NOT a manual override.
+
+        In idle mode temp_control sent fan_bypass_auto, so the device is
+        free to move the damper on its own.  These changes must not
+        disable temp_control.
+        """
+        automation_manager._mode["32:153289"] = "idle"
+        automation_manager._last_bypass_command_time["32:153289"] = 0.0
+        automation_manager.hass.states.get = MagicMock(
+            return_value=MagicMock(state="on")
+        )
+        with patch.object(
+            ExtrasBaseAutomation,
+            "_async_handle_state_change",
+            new_callable=AsyncMock,
+        ) as mock_super:
+            await automation_manager._async_handle_state_change(
+                "binary_sensor.32_153289_bypass_position",
+                MagicMock(state="open"),
+                MagicMock(state="closed"),
+            )
+            automation_manager.hass.services.async_call.assert_not_called()
+            mock_super.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_bypass_change_no_old_state_passes_through(self, automation_manager):


### PR DESCRIPTION
The bypass "external change" safety net was disabling temp_control in cases where the bypass movement was expected, not a manual override:

1. In idle mode temp_control sends fan_bypass_auto, handing bypass control back to the FAN device. The device is then free to move the damper on its own, but the safety net treated any bypass position change (after the 10s command window) as a manual override and turned temp_control off.

2. The safety net only refreshed its "last command" timestamp when the mode *changed*, so in a steady state the timestamp went stale and any bypass movement tripped the net. This included bypass movements induced by other features (e.g. humidity_control veto forcing fan_low) that cause the device to reposition the damper.

Fix: only arm the safety net when temp_control is actively forcing a bypass state (cooling = bypass open, heating_retention = bypass close). In idle mode, bypass changes are expected and pass through to the normal state-change handler.

Additionally, _handle_disabled and stop() now send fan_bypass_auto when temp_control was actively forcing a bypass state, so the device resumes autonomous bypass control instead of being left in a forced open/close position.

Generated with [Devin](https://devin.ai)