### PR TITLE
fix: refresh-all-parameters button blocked by chicken-and-egg 2411 guard

### DIFF
--- a/custom_components/ramses_extras/framework/helpers/ramses_commands.py
+++ b/custom_components/ramses_extras/framework/helpers/ramses_commands.py
@@ -354,11 +354,33 @@ class RamsesCommands:
         # Convert device_id format if needed (32_153289 -> 32:153289)
         device_id_formatted = device_id.replace("_", ":")
 
-        # Ensure the ramses_rf device advertises 2411 support before spamming requests
+        # Resolve the ramses_cc broker first — without it nothing works.
+        ramses_cc_data = self.hass.data.get("ramses_cc", {})
+        broker = None
+        for _entry_id, broker_instance in ramses_cc_data.items():
+            if hasattr(broker_instance, "get_all_fan_params"):
+                broker = broker_instance
+                break
+
+        if not broker:
+            return CommandResult(
+                success=False, error_message="ramses_cc broker not found"
+            )
+
+        # Only block when the device can't be found at all.  The
+        # supports_2411 flag defaults to False in ramses_rf and is only
+        # set to True *after* the device receives a 2411 message — so
+        # blocking on False creates a chicken-and-egg: the refresh is
+        # the mechanism that triggers 2411 messages, but it's blocked
+        # because no 2411 messages have arrived yet (e.g. after HA
+        # restart).  Since update_fan_params is only called from the
+        # FAN card/service, the device is always a FAN that may support
+        # 2411; allow the refresh and let the requests fail naturally
+        # if the device truly doesn't support it.
         supports_2411 = await self._device_supports_2411(device_id_formatted)
-        if supports_2411 is False:
+        if supports_2411 is None:
             msg = (
-                f"Device {device_id_formatted} does not advertise 2411 support; "
+                f"Device {device_id_formatted} not found in ramses_rf; "
                 "skipping update_fan_params"
             )
             _LOGGER.info(msg)
@@ -383,18 +405,6 @@ class RamsesCommands:
             del self._update_fan_params_tasks[device_id_formatted]
 
         try:
-            ramses_cc_data = self.hass.data.get("ramses_cc", {})
-            broker = None
-            for entry_id, broker_instance in ramses_cc_data.items():
-                if hasattr(broker_instance, "get_all_fan_params"):
-                    broker = broker_instance
-                    break
-
-            if not broker:
-                return CommandResult(
-                    success=False, error_message="ramses_cc broker not found"
-                )
-
             call_data = {"device_id": device_id_formatted}
             if from_id:
                 call_data["from_id"] = from_id

--- a/docs/notepad.txt
+++ b/docs/notepad.txt
@@ -119,22 +119,6 @@ we should be able to simulate and test this
   Periodic RQ polling would restore the fast update feel without the command side-effects.
   Note: this is prepared in RF and for now we should not do this in extras
 
-- **Migrate frontend message delivery to Event Entity (with backward compat)** — DONE:
-  ramses_cc >= 0.55.6 has a proper HA Event Entity (`event.ramses_cc_regex_event`) that fires
-  for every inbound packet when `message_events` regex is configured (e.g. `.*`). This is the
-  modern HA-recommended way (see ramses_cc issue #552) — it fires as `state_changed`, which is
-  in HA's websocket SUBSCRIBE_ALLOWLIST, so any user can subscribe (not just admin).
-  Implementation (ramses-message-broker.js):
-  - Modern path: subscribes to `state_changed`, filters for `event.ramses_cc_regex_event`,
-    extracts data from `new_state.attributes.data` (same code/src/verb/payload structure).
-  - Legacy path: also subscribes to `ramses_cc_message` bus events (for ramses_cc < 0.55.6
-    or when message_events is not configured). May fail for non-admin — expected.
-  - Dedup: 5s TTL Map keyed by `src|code|dtm` prevents processing the same message twice
-    when both paths are active.
-  - Backend (`ramses_message_stream.py`) unchanged — keeps firing bus events for backward compat
-    and keeps `add_msg_handler` for backend automations/traffic collector.
-  - Verified: non-admin websocket test receives 31DA/10D0/22F1/31D9 events via the modern path.
-
 
 -- other:
 
@@ -204,3 +188,20 @@ Traceback (most recent call last):
     raise TypeError("Either a port_name or an input_file must be specified")
 TypeError: Either a port_name or an input_file must be specified
 2026-05-05 16:04:23.891 INFO (MainThread) [homeassistant.config_entries] Config entry 'RAMSES RF' for ramses_cc integration not ready yet: Setup failed: Either a port_name or an input_file must be specified; Retrying in 5 seconds
+
+
+--- TODO: configurable comfort temp source for temp_control ---
+
+Currently temp_control reads comfort temp from `number.{device_id}_param_75`
+(2411 param 75). When a FAN doesn't support 2411 params (or param_75 is not
+set), `_as_float` raises ValueError and the automation silently does nothing
+— no bypass commands, no status update, no error visible on the card.
+
+Plan: add a config option in temp_control to use an external comfort temp
+entity (HA helper like input_number) as an alternative/override for param_75.
+- config_flow: add "comfort_temp_entity" optional field
+- const.py: add to entity_mappings as fallback
+- automation.py _get_device_entity_states: try param_75 first, fall back to
+  the configured external entity; if both unavailable, set status to
+  "waiting_for_comfort_temp" instead of silently skipping
+- card: show a clear indicator when comfort temp is missing

--- a/tests/framework/helpers/test_ramses_commands.py
+++ b/tests/framework/helpers/test_ramses_commands.py
@@ -323,13 +323,13 @@ async def test_update_fan_params_error(ramses_commands, hass):
 
 
 @pytest.mark.asyncio
-async def test_update_fan_params_blocked_when_no_2411_support(ramses_commands, hass):
-    """Ensure fan param refresh is skipped when device lacks 2411 support."""
+async def test_update_fan_params_blocked_when_device_not_found(ramses_commands, hass):
+    """Ensure fan param refresh is skipped when device can't be found."""
     hass.data = {"ramses_cc": {"entry_id": MagicMock()}}
 
     with (
         patch.object(
-            ramses_commands, "_device_supports_2411", return_value=False
+            ramses_commands, "_device_supports_2411", return_value=None
         ) as mock_supports,
         patch.dict(hass.data["ramses_cc"], {}, clear=False),
     ):
@@ -337,7 +337,34 @@ async def test_update_fan_params_blocked_when_no_2411_support(ramses_commands, h
 
     mock_supports.assert_called_once()
     assert result.success is False
-    assert "does not advertise 2411" in result.error_message
+    assert "not found in ramses_rf" in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_update_fan_params_allowed_when_2411_flag_false(ramses_commands, hass):
+    """Fan param refresh proceeds even when supports_2411 is False.
+
+    The supports_2411 flag defaults to False and only becomes True after
+    the device receives a 2411 message.  Blocking on False creates a
+    chicken-and-egg: the refresh is the mechanism that triggers 2411
+    messages.  So False (device found, no 2411 yet) must be allowed
+    through; only None (device not found) is blocked.
+    """
+    mock_broker = MagicMock()
+    mock_broker.get_all_fan_params = MagicMock()
+
+    hass.data = {"ramses_cc": {"entry_id": mock_broker}}
+
+    with (
+        patch.object(
+            ramses_commands, "_device_supports_2411", return_value=False
+        ) as mock_supports,
+    ):
+        result = await ramses_commands.update_fan_params("32_123456")
+
+    mock_supports.assert_called_once()
+    assert result.success is True
+    mock_broker.get_all_fan_params.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The _device_supports_2411 guard (added in c0d1351) blocked the update_fan_params refresh when the device's supports_2411 flag was False.  But that flag defaults to False in ramses_rf and only becomes True *after* the device receives a 2411 message — so after an HA restart (before any 2411 messages arrive), the refresh button did nothing because the guard blocked the very mechanism that would set the flag to True.

Fix: only block when the device can't be found at all (None).  When the device is found but supports_2411 is False (no 2411 messages yet), allow the refresh to proceed — the requests will fail naturally if the device truly doesn't support 2411.

Generated with [Devin](https://devin.ai)