### PR TITLE
fix(104): add LogOnce helper, warn once for missing bound REM

### DIFF
--- a/custom_components/ramses_extras/framework/helpers/log_once.py
+++ b/custom_components/ramses_extras/framework/helpers/log_once.py
@@ -1,0 +1,245 @@
+"""Log-once helper: emit log messages with dedup strategies.
+
+Some log messages (especially startup warnings about missing
+configuration) should only be emitted once — not repeated on every
+restart or every reload.  This helper provides a reusable, generic
+mechanism for that.
+
+Strategies (``LogWhen``):
+
+- ``RESTART``      — log once per HA process (in-memory set, not
+  persisted).  Resets when HA restarts.
+- ``INSTALL``      — log once ever (persisted in HA ``.storage``).
+  Never repeats unless ``clear()`` is called.
+- ``VERSION_BUMP`` — log once per integration version (persisted with
+  the version string).  Re-logs when the integration is upgraded.
+- ``INTERVAL``     — log once, then suppress for *N* days (persisted
+  with an expiry timestamp).  Re-logs after the interval elapses.
+- ``ALWAYS``       — no dedup; equivalent to a regular ``logger.log()``
+  call.  Useful for a unified call site where only some messages need
+  dedup.
+
+All persisted state lives in a single HA ``Store`` (one ``.storage``
+file), keyed by the caller-provided ``key``.  This keeps disk I/O
+low and makes it easy to inspect or reset all flags at once.
+
+Example::
+
+    warner = LogOnce(hass)
+    await warner.log(
+        key="bound_rem_missing",
+        msg="No bound REM configured — ...",
+        level=logging.WARNING,
+        when=LogWhen.INSTALL,
+    )
+
+    # When the situation resolves, clear the flag so a future
+    # regression re-warns once:
+    await warner.clear("bound_rem_missing")
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+_DOMAIN = "ramses_extras"
+_STORE_VERSION = 1
+_STORE_KEY = "ramses_extras.log_once"
+_RESTART_SET_KEY = "_log_once_restart_set"
+
+_SECONDS_PER_DAY = 86_400.0
+
+
+class LogWhen(StrEnum):
+    """When a log-once message should be (re-)emitted."""
+
+    RESTART = "restart"
+    INSTALL = "install"
+    VERSION_BUMP = "version_bump"
+    INTERVAL = "interval"
+    ALWAYS = "always"
+
+
+class LogOnce:
+    """Helper to log messages with once-only dedup strategies.
+
+    A single instance can be reused for multiple keys.  State is
+    persisted in a shared HA ``Store`` (one ``.storage`` file for all
+    keys) so that ``INSTALL`` / ``VERSION_BUMP`` / ``INTERVAL``
+    strategies survive HA restarts.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._hass = hass
+        self._logger = logger or _LOGGER
+
+    async def log(
+        self,
+        *,
+        key: str,
+        msg: str,
+        level: int = logging.WARNING,
+        when: LogWhen = LogWhen.INSTALL,
+        interval_days: float | None = None,
+        args: tuple[Any, ...] | None = None,
+        logger: logging.Logger | None = None,
+    ) -> bool:
+        """Log *msg* at *level* if the dedup strategy allows it.
+
+        :param key: Unique persistence key (scoped to this helper's
+            store).  The same key must be used for the same message
+            across calls/restarts.
+        :param msg: Log message (may include ``%s``-style placeholders
+            if *args* is provided).
+        :param level: Standard ``logging`` level constant, e.g.
+            ``logging.WARNING`` or ``logging.INFO``.
+        :param when: Dedup strategy.  See :class:`LogWhen`.
+        :param interval_days: Required for ``LogWhen.INTERVAL``;
+            ignored otherwise.  Number of days to suppress after
+            logging.
+        :param args: Optional format args for lazy ``%``-interpolation
+            (passed through to ``logger.log``).
+        :param logger: Override the logger for this call only.  Defaults
+            to the logger set at construction (or the module logger).
+        :return: ``True`` if the message was logged this call,
+            ``False`` if it was suppressed by the dedup strategy.
+        """
+        log = logger or self._logger
+        log_args = args or ()
+
+        # --- strategies that don't need persistence ------------------
+
+        if when == LogWhen.ALWAYS:
+            log.log(level, msg, *log_args)
+            return True
+
+        if when == LogWhen.RESTART:
+            data = self._hass.data.setdefault(_DOMAIN, {})
+            restart_set: set[str] = data.setdefault(_RESTART_SET_KEY, set())
+            if key in restart_set:
+                return False
+            restart_set.add(key)
+            log.log(level, msg, *log_args)
+            return True
+
+        # --- persisted strategies ------------------------------------
+
+        state = await self._load_state()
+        entry = state.get(key, {})
+        now = time.time()
+
+        should_log = False
+        new_entry: dict[str, Any] = {"logged_at": now}
+
+        if when == LogWhen.INSTALL:
+            if not entry:
+                should_log = True
+
+        elif when == LogWhen.VERSION_BUMP:
+            version = await self._get_integration_version()
+            new_entry["version"] = version
+            if not entry or entry.get("version") != version:
+                should_log = True
+
+        elif when == LogWhen.INTERVAL:
+            days = interval_days if interval_days is not None else 1.0
+            new_entry["expires_at"] = now + (days * _SECONDS_PER_DAY)
+            expires_at = entry.get("expires_at")
+            if not isinstance(expires_at, (int, float)) or now >= expires_at:
+                should_log = True
+
+        if should_log:
+            state[key] = new_entry
+            await self._save_state(state)
+            log.log(level, msg, *log_args)
+            return True
+
+        return False
+
+    async def clear(self, key: str) -> None:
+        """Clear the dedup state for *key* so it can fire again.
+
+        Works for all strategies (``RESTART`` in-memory set and the
+        persisted store).  Use this when a previously-warned condition
+        has been resolved, so that a future regression re-warns once.
+        """
+        # Clear from in-memory restart set
+        data = self._hass.data.get(_DOMAIN, {})
+        restart_set = data.get(_RESTART_SET_KEY)
+        if isinstance(restart_set, set):
+            restart_set.discard(key)
+
+        # Clear from persisted store
+        state = await self._load_state()
+        if key in state:
+            state.pop(key)
+            await self._save_state(state)
+
+    async def is_logged(self, key: str) -> bool:
+        """Check whether *key* has been logged (without logging).
+
+        For ``RESTART``: checks the in-memory set.
+        For persisted strategies: checks whether the key exists in the
+        store (does **not** check interval expiry or version match —
+        the caller should know which strategy was used).
+        """
+        data = self._hass.data.get(_DOMAIN, {})
+        restart_set = data.get(_RESTART_SET_KEY)
+        if isinstance(restart_set, set) and key in restart_set:
+            return True
+
+        state = await self._load_state()
+        return key in state
+
+    # ------------------------------------------------------------------
+    #  Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_integration_version(self) -> str:
+        """Return the current integration version, cached if available."""
+        data = self._hass.data.setdefault(_DOMAIN, {})
+        cached = data.get("_integration_version")
+        if isinstance(cached, str) and cached:
+            return cached
+        try:
+            from ..setup.cards import async_get_integration_version
+
+            version = await async_get_integration_version(self._hass)
+            return str(version)
+        except Exception:
+            return "0.0.0"
+
+    async def _load_state(self) -> dict[str, Any]:
+        """Load the persisted log-once state dict."""
+        try:
+            from homeassistant.helpers.storage import Store
+
+            store = Store(self._hass, _STORE_VERSION, _STORE_KEY)
+            data = await store.async_load()
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            _LOGGER.debug("Failed to load log-once state", exc_info=True)
+        return {}
+
+    async def _save_state(self, state: dict[str, Any]) -> None:
+        """Persist the log-once state dict."""
+        try:
+            from homeassistant.helpers.storage import Store
+
+            store = Store(self._hass, _STORE_VERSION, _STORE_KEY)
+            await store.async_save(state)
+        except Exception:
+            _LOGGER.debug("Failed to save log-once state", exc_info=True)

--- a/custom_components/ramses_extras/framework/helpers/rf_config_validation.py
+++ b/custom_components/ramses_extras/framework/helpers/rf_config_validation.py
@@ -37,6 +37,24 @@ _SZ_BOUND_TO = "bound_to"
 # Message codes that ramses_extras features rely on
 _REQUIRED_MSG_CODES = ("31DA", "10D0")
 
+# Log-once key for the missing-bound-REM warning.  Used by the caller
+# (framework/setup/validation.py) with the LogOnce helper so that the
+# warning is emitted only once across restarts.  Some FAN devices do
+# not support a bound REM at all (manufacturer intentional), so the
+# warning is not actionable for those users and should not repeat.
+BOUND_REM_WARNED_KEY = "bound_rem_missing"
+
+# The warning message text.  Exposed as a constant so the caller can
+# pass it to LogOnce.log() without duplicating the wording.
+BOUND_REM_WARNED_MSG = (
+    "No bound REM configured in ramses_cc known_list — "
+    "remote_binding and FAN command relay will not work. "
+    "If your FAN device supports a bound REM, configure one "
+    "for it in ramses_cc configuration under Known Devices. "
+    "(This warning is emitted only once; it will not repeat "
+    "on subsequent restarts.)"
+)
+
 
 def _get_ramses_cc_options(hass: HomeAssistant) -> dict[str, Any] | None:
     """Return the ramses_cc config entry options, or None if not loaded."""
@@ -162,6 +180,15 @@ def log_validation_results(results: dict[str, bool]) -> None:
 
     Called after validation to inform the user of any settings that
     need to be adjusted in ramses_cc for ramses_extras to work correctly.
+
+    .. note::
+
+        The missing-bound-REM warning is **not** logged here.  It uses
+        the :class:`~..log_once.LogOnce` helper (strategy
+        ``LogWhen.INSTALL``) so that it is emitted only once across
+        restarts.  The caller (``validate_rf_config``) handles it
+        separately because some FAN devices do not support a bound REM
+        at all, making the warning non-actionable for those users.
     """
 
     if not results.get("ramses_cc_loaded"):
@@ -191,14 +218,6 @@ def log_validation_results(results: dict[str, bool]) -> None:
             "receive real-time FAN status updates. Update the regex in "
             "ramses_cc configuration under Advanced Features to include "
             "'31DA|10D0'."
-        )
-
-    if not results.get("has_bound_rem"):
-        _LOGGER.warning(
-            "No bound REM configured in ramses_cc known_list — "
-            "remote_binding and FAN command relay will not work. "
-            "Configure a bound REM for your FAN device in ramses_cc "
-            "configuration under Known Devices."
         )
 
     if not results.get("recorder_loaded"):

--- a/custom_components/ramses_extras/framework/setup/validation.py
+++ b/custom_components/ramses_extras/framework/setup/validation.py
@@ -14,7 +14,10 @@ import logging
 
 from homeassistant.core import HomeAssistant
 
+from ..helpers.log_once import LogOnce, LogWhen
 from ..helpers.rf_config_validation import (
+    BOUND_REM_WARNED_KEY,
+    BOUND_REM_WARNED_MSG,
     log_validation_results,
     validate_ramses_cc_config,
 )
@@ -33,11 +36,37 @@ async def validate_rf_config(hass: HomeAssistant) -> None:
 
     Logs a WARNING for each missing item with actionable instructions.
 
+    The missing-bound-REM warning is emitted only once across restarts
+    via the :class:`LogOnce` helper (strategy ``LogWhen.INSTALL``).
+    Some FAN devices do not support a bound REM at all, so the warning
+    is not actionable for those users and should not repeat on every
+    restart.  The flag is cleared again as soon as a bound REM *is*
+    detected, so a later regression re-warns once.  See GitHub issue 104.
+
     :param hass: Home Assistant instance
     """
     _LOGGER.debug("Validating ramses_cc configuration for ramses_extras")
 
     results = await validate_ramses_cc_config(hass)
+
+    # Log the non-dedup warnings (send_packet, message_events, recorder).
     log_validation_results(results)
+
+    # Handle the bound-REM warning with LogOnce dedup.
+    # Warned once per install; cleared when a bound REM is detected so
+    # that a future regression re-warns.
+    warner = LogOnce(hass, logger=_LOGGER)
+
+    if results.get("ramses_cc_loaded") and not results.get("has_bound_rem"):
+        await warner.log(
+            key=BOUND_REM_WARNED_KEY,
+            msg=BOUND_REM_WARNED_MSG,
+            level=logging.WARNING,
+            when=LogWhen.INSTALL,
+        )
+    elif results.get("has_bound_rem"):
+        # Situation resolved — clear the flag so a future regression
+        # re-warns once.
+        await warner.clear(BOUND_REM_WARNED_KEY)
 
     _LOGGER.debug("RF config validation complete: %s", results)

--- a/tests/framework/test_log_once.py
+++ b/tests/framework/test_log_once.py
@@ -1,0 +1,488 @@
+"""Tests for the LogOnce helper."""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.ramses_extras.framework.helpers.log_once import (
+    _DOMAIN,
+    _RESTART_SET_KEY,
+    _STORE_KEY,
+    LogOnce,
+    LogWhen,
+)
+
+
+def _make_hass() -> MagicMock:
+    """Create a MagicMock hass with the data dict LogOnce expects."""
+    hass = MagicMock()
+    hass.data = {_DOMAIN: {}}
+    return hass
+
+
+@contextmanager
+def _patch_store(load_return=None, save_mock=None):
+    """Patch HA's Store with controllable load/save (context manager).
+
+    Usage::
+
+        with _patch_store(load_return={...}) as mock_store_cls:
+            ...
+    """
+    with patch("homeassistant.helpers.storage.Store") as mock_store_cls:
+        mock_store_cls.return_value.async_load = AsyncMock(return_value=load_return)
+        mock_store_cls.return_value.async_save = save_mock or AsyncMock()
+        yield mock_store_cls
+
+
+class TestLogWhen:
+    """Tests for the LogWhen enum."""
+
+    def test_str_values(self) -> None:
+        assert LogWhen.RESTART == "restart"
+        assert LogWhen.INSTALL == "install"
+        assert LogWhen.VERSION_BUMP == "version_bump"
+        assert LogWhen.INTERVAL == "interval"
+        assert LogWhen.ALWAYS == "always"
+
+
+class TestLogAlways:
+    """LogWhen.ALWAYS — no dedup, always logs."""
+
+    @pytest.mark.asyncio
+    async def test_logs_every_time(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+        msg = "test always message"
+
+        r1 = await warner.log(
+            key="k1", msg=msg, level=logging.WARNING, when=LogWhen.ALWAYS
+        )
+        r2 = await warner.log(
+            key="k1", msg=msg, level=logging.WARNING, when=LogWhen.ALWAYS
+        )
+
+        assert r1 is True
+        assert r2 is True
+        assert caplog.text.count(msg) == 2
+
+    @pytest.mark.asyncio
+    async def test_respects_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("DEBUG")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        await warner.log(
+            key="k1", msg="debug msg", level=logging.DEBUG, when=LogWhen.ALWAYS
+        )
+        assert "debug msg" in caplog.text
+
+
+class TestLogRestart:
+    """LogWhen.RESTART — once per HA process (in-memory)."""
+
+    @pytest.mark.asyncio
+    async def test_logs_first_time(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        result = await warner.log(
+            key="k1", msg="restart msg", level=logging.WARNING, when=LogWhen.RESTART
+        )
+        assert result is True
+        assert "restart msg" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_suppresses_second_time(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        await warner.log(key="k1", msg="first", when=LogWhen.RESTART)
+        result = await warner.log(key="k1", msg="second", when=LogWhen.RESTART)
+
+        assert result is False
+        assert "second" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_different_keys_log_independently(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        r1 = await warner.log(key="k1", msg="msg1", when=LogWhen.RESTART)
+        r2 = await warner.log(key="k2", msg="msg2", when=LogWhen.RESTART)
+
+        assert r1 is True
+        assert r2 is True
+        assert "msg1" in caplog.text
+        assert "msg2" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_uses_in_memory_set(self) -> None:
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        await warner.log(key="k1", msg="msg", when=LogWhen.RESTART)
+
+        restart_set = hass.data[_DOMAIN][_RESTART_SET_KEY]
+        assert isinstance(restart_set, set)
+        assert "k1" in restart_set
+
+
+class TestLogInstall:
+    """LogWhen.INSTALL — once ever (persisted)."""
+
+    @pytest.mark.asyncio
+    async def test_logs_when_no_prior_state(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        with _patch_store(load_return=None):
+            warner = LogOnce(hass)
+            result = await warner.log(key="k1", msg="install msg", when=LogWhen.INSTALL)
+            assert result is True
+            assert "install msg" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_suppresses_when_already_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        with _patch_store(load_return={"k1": {"logged_at": time.time()}}):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1", msg="should not appear", when=LogWhen.INSTALL
+            )
+            assert result is False
+            assert "should not appear" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_persists_after_logging(self) -> None:
+        hass = _make_hass()
+        save_mock = AsyncMock()
+        with _patch_store(load_return=None, save_mock=save_mock):
+            warner = LogOnce(hass)
+            await warner.log(key="k1", msg="msg", when=LogWhen.INSTALL)
+            save_mock.assert_awaited_once()
+            saved_data = save_mock.call_args.args[0]
+            assert "k1" in saved_data
+            assert "logged_at" in saved_data["k1"]
+
+
+class TestLogVersionBump:
+    """LogWhen.VERSION_BUMP — once per integration version."""
+
+    @pytest.mark.asyncio
+    async def test_logs_on_first_run(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        hass.data[_DOMAIN]["_integration_version"] = "1.0.0"
+        with _patch_store(load_return=None):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1", msg="version msg", when=LogWhen.VERSION_BUMP
+            )
+            assert result is True
+            assert "version msg" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_suppresses_same_version(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        hass.data[_DOMAIN]["_integration_version"] = "1.0.0"
+        with _patch_store(
+            load_return={"k1": {"logged_at": time.time(), "version": "1.0.0"}}
+        ):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1", msg="should not appear", when=LogWhen.VERSION_BUMP
+            )
+            assert result is False
+            assert "should not appear" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_re_logs_on_version_change(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        hass.data[_DOMAIN]["_integration_version"] = "2.0.0"
+        with _patch_store(
+            load_return={"k1": {"logged_at": time.time(), "version": "1.0.0"}}
+        ):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1", msg="new version msg", when=LogWhen.VERSION_BUMP
+            )
+            assert result is True
+            assert "new version msg" in caplog.text
+
+
+class TestLogInterval:
+    """LogWhen.INTERVAL — once per N days."""
+
+    @pytest.mark.asyncio
+    async def test_logs_when_no_prior_state(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        with _patch_store(load_return=None):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1",
+                msg="interval msg",
+                when=LogWhen.INTERVAL,
+                interval_days=7,
+            )
+            assert result is True
+            assert "interval msg" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_suppresses_within_interval(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        now = time.time()
+        with _patch_store(
+            load_return={"k1": {"logged_at": now, "expires_at": now + 86_400 * 7}}
+        ):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1",
+                msg="should not appear",
+                when=LogWhen.INTERVAL,
+                interval_days=7,
+            )
+            assert result is False
+            assert "should not appear" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_re_logs_after_expiry(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        now = time.time()
+        with _patch_store(
+            load_return={
+                "k1": {
+                    "logged_at": now - 86_400 * 10,
+                    "expires_at": now - 86_400 * 3,
+                }
+            }
+        ):
+            warner = LogOnce(hass)
+            result = await warner.log(
+                key="k1",
+                msg="re-logged after expiry",
+                when=LogWhen.INTERVAL,
+                interval_days=7,
+            )
+            assert result is True
+            assert "re-logged after expiry" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_one_day_when_not_specified(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        save_mock = AsyncMock()
+        with _patch_store(load_return=None, save_mock=save_mock):
+            warner = LogOnce(hass)
+            await warner.log(key="k1", msg="msg", when=LogWhen.INTERVAL)
+            saved = save_mock.call_args.args[0]
+            # expires_at should be ~now + 1 day
+            assert "expires_at" in saved["k1"]
+            assert saved["k1"]["expires_at"] > time.time()
+
+
+class TestClear:
+    """Tests for LogOnce.clear()."""
+
+    @pytest.mark.asyncio
+    async def test_clear_removes_from_persisted_store(self) -> None:
+        hass = _make_hass()
+        save_mock = AsyncMock()
+        with _patch_store(
+            load_return={"k1": {"logged_at": time.time()}}, save_mock=save_mock
+        ):
+            warner = LogOnce(hass)
+            await warner.clear("k1")
+            save_mock.assert_awaited_once()
+            saved = save_mock.call_args.args[0]
+            assert "k1" not in saved
+
+    @pytest.mark.asyncio
+    async def test_clear_removes_from_restart_set(self) -> None:
+        hass = _make_hass()
+        hass.data[_DOMAIN][_RESTART_SET_KEY] = {"k1", "k2"}
+        with _patch_store(load_return={}):
+            warner = LogOnce(hass)
+            await warner.clear("k1")
+            assert "k1" not in hass.data[_DOMAIN][_RESTART_SET_KEY]
+            assert "k2" in hass.data[_DOMAIN][_RESTART_SET_KEY]
+
+    @pytest.mark.asyncio
+    async def test_clear_nonexistent_key_no_error(self) -> None:
+        hass = _make_hass()
+        with _patch_store(load_return=None):
+            warner = LogOnce(hass)
+            # Should not raise
+            await warner.clear("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_clear_allows_re_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        with _patch_store(load_return={"k1": {"logged_at": time.time()}}):
+            warner = LogOnce(hass)
+            # First call suppressed
+            r1 = await warner.log(key="k1", msg="msg1", when=LogWhen.INSTALL)
+            assert r1 is False
+            # Clear
+            await warner.clear("k1")
+            # Now should log again
+            r2 = await warner.log(key="k1", msg="msg2", when=LogWhen.INSTALL)
+            assert r2 is True
+            assert "msg2" in caplog.text
+
+
+class TestIsLogged:
+    """Tests for LogOnce.is_logged()."""
+
+    @pytest.mark.asyncio
+    async def test_true_for_restart_key(self) -> None:
+        hass = _make_hass()
+        hass.data[_DOMAIN][_RESTART_SET_KEY] = {"k1"}
+        with _patch_store(load_return={}):
+            warner = LogOnce(hass)
+            assert await warner.is_logged("k1") is True
+
+    @pytest.mark.asyncio
+    async def test_true_for_persisted_key(self) -> None:
+        hass = _make_hass()
+        with _patch_store(load_return={"k1": {"logged_at": time.time()}}):
+            warner = LogOnce(hass)
+            assert await warner.is_logged("k1") is True
+
+    @pytest.mark.asyncio
+    async def test_false_for_unknown_key(self) -> None:
+        hass = _make_hass()
+        with _patch_store(load_return={}):
+            warner = LogOnce(hass)
+            assert await warner.is_logged("unknown") is False
+
+
+class TestStoreErrorHandling:
+    """LogOnce should never raise on store errors."""
+
+    @pytest.mark.asyncio
+    async def test_load_error_returns_empty(self) -> None:
+        hass = _make_hass()
+        with patch("homeassistant.helpers.storage.Store") as mock_store_cls:
+            mock_store_cls.return_value.async_load = AsyncMock(
+                side_effect=RuntimeError("disk")
+            )
+            mock_store_cls.return_value.async_save = AsyncMock()
+            warner = LogOnce(hass)
+            # Should not raise; should treat as empty state -> log
+            result = await warner.log(key="k1", msg="msg", when=LogWhen.INSTALL)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_save_error_does_not_raise(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        with patch("homeassistant.helpers.storage.Store") as mock_store_cls:
+            mock_store_cls.return_value.async_load = AsyncMock(return_value=None)
+            mock_store_cls.return_value.async_save = AsyncMock(
+                side_effect=RuntimeError("disk")
+            )
+            warner = LogOnce(hass)
+            # Should log the message even if saving fails
+            result = await warner.log(key="k1", msg="msg", when=LogWhen.INSTALL)
+            assert result is True
+            assert "msg" in caplog.text
+
+
+class TestStoreKey:
+    """Verify the shared store key."""
+
+    @pytest.mark.asyncio
+    async def test_uses_correct_store_key(self) -> None:
+        hass = _make_hass()
+        with _patch_store(load_return=None) as ctx:
+            warner = LogOnce(hass)
+            await warner.log(key="k1", msg="msg", when=LogWhen.INSTALL)
+            assert ctx.call_args is not None
+            # Store(hass, version, key) — verify the key argument
+            assert ctx.call_args.args[2] == _STORE_KEY
+
+
+class TestLoggerOverride:
+    """Tests for logger parameter handling."""
+
+    @pytest.mark.asyncio
+    async def test_custom_logger_at_construction(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        custom_logger = logging.getLogger("custom.test.log_once")
+        hass = _make_hass()
+        warner = LogOnce(hass, logger=custom_logger)
+
+        await warner.log(key="k1", msg="custom logger msg", when=LogWhen.ALWAYS)
+        assert "custom logger msg" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logger_override_per_call(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        call_logger = logging.getLogger("custom.per_call.log_once")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        await warner.log(
+            key="k1", msg="per-call msg", when=LogWhen.ALWAYS, logger=call_logger
+        )
+        assert "per-call msg" in caplog.text
+
+
+class TestLazyFormatArgs:
+    """Tests for lazy % formatting via args parameter."""
+
+    @pytest.mark.asyncio
+    async def test_args_passed_to_logger(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        hass = _make_hass()
+        warner = LogOnce(hass)
+
+        await warner.log(
+            key="k1",
+            msg="value is %s and %s",
+            args=("hello", 42),
+            when=LogWhen.ALWAYS,
+        )
+        assert "value is hello and 42" in caplog.text

--- a/tests/framework/test_rf_config_validation.py
+++ b/tests/framework/test_rf_config_validation.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.ramses_extras.framework.helpers.rf_config_validation import (
+    BOUND_REM_WARNED_KEY,
+    BOUND_REM_WARNED_MSG,
     _check_bound_rem,
     _check_message_events,
     _check_recorder,
@@ -197,7 +199,13 @@ class TestValidateRamsesCcConfig:
 
 
 class TestLogValidationResults:
-    """Tests for log_validation_results."""
+    """Tests for log_validation_results.
+
+    Note: the bound-REM warning is NOT logged by log_validation_results
+    anymore — it is handled by the caller via the LogOnce helper.
+    These tests verify the remaining warnings (send_packet,
+    message_events, recorder).
+    """
 
     def test_ramses_cc_not_loaded_skips_warnings(self) -> None:
         # Should not log additional warnings when ramses_cc not loaded
@@ -264,7 +272,10 @@ class TestLogValidationResults:
         )
         assert "31DA|10D0" in caplog.text
 
-    def test_no_bound_rem_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_no_bound_rem_does_not_warn_here(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """bound-REM warning is NOT in log_validation_results anymore."""
         caplog.set_level("WARNING")
         log_validation_results(
             {
@@ -276,7 +287,8 @@ class TestLogValidationResults:
                 "recorder_loaded": True,
             }
         )
-        assert "bound REM" in caplog.text
+        # The bound-REM warning is handled by the caller via LogOnce.
+        assert "bound REM" not in caplog.text
 
     def test_recorder_not_loaded_warning(
         self, caplog: pytest.LogCaptureFixture
@@ -293,3 +305,17 @@ class TestLogValidationResults:
             }
         )
         assert "recorder" in caplog.text.lower()
+
+
+class TestBoundRemWarningConstants:
+    """Verify the exposed constants used by the caller."""
+
+    def test_key_is_nonempty_string(self) -> None:
+        assert isinstance(BOUND_REM_WARNED_KEY, str)
+        assert BOUND_REM_WARNED_KEY
+
+    def test_msg_contains_if_supported(self) -> None:
+        assert "If your FAN device supports a bound REM" in BOUND_REM_WARNED_MSG
+
+    def test_msg_mentions_once_only(self) -> None:
+        assert "only once" in BOUND_REM_WARNED_MSG


### PR DESCRIPTION
Some FAN devices do not support a bound REM at all (manufacturer intentional), so the missing-bound-REM warning was not actionable for those users and repeated on every HA restart.

Add a reusable LogOnce helper (framework/helpers/log_once.py) with dedup strategies: RESTART, INSTALL, VERSION_BUMP, INTERVAL, ALWAYS. Persisted state lives in a single HA .storage Store, keyed by caller- provided key. Store errors are swallowed defensively.

Refactor the bound-REM warning to use LogOnce with LogWhen.INSTALL: warn once, then stay silent on subsequent restarts. The flag is cleared when a bound REM is detected, so a future regression re-warns.

Soften the warning text with "If your FAN device supports a bound REM" wording and note it won't repeat.

Issue: https://github.com/wimpie70/ramses_extras/issues/104