### PR TITLE
Fix/106 temp control turned off after cooling

### DIFF
--- a/custom_components/ramses_extras/features/temp_control/automation.py
+++ b/custom_components/ramses_extras/features/temp_control/automation.py
@@ -611,10 +611,26 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
             len(area_results),
         )
 
-        # Enforce minimum interval between bypass mode changes
+        # Enforce minimum interval between bypass mode changes.
+        # Only suppress transitions between *active* forcing modes
+        # (cooling↔heating_retention) to prevent the bypass damper from
+        # rapidly oscillating open/close.  Transitions to/from idle must
+        # always be allowed:
+        #   - cooling/heating_retention → idle releases bypass control
+        #     back to the device (fan_bypass_auto); this is not oscillation.
+        #   - idle → cooling/heating_retention is a new decision, not a
+        #     reversal of a recent one.
+        # Suppressing cooling→idle is especially harmful: it keeps
+        # temp_control in an active forcing mode with a stale command
+        # timestamp, so when the device legitimately moves the bypass on
+        # its own (conditions changed), the bypass safety net falsely
+        # detects a "manual override" and turns temp_control off.
+        active_modes = {"cooling", "heating_retention"}
         last_change = self._last_bypass_change.get(device_id, 0.0)
         if (
             desired_mode != prev_mode
+            and desired_mode in active_modes
+            and prev_mode in active_modes
             and (now - last_change) < settings.min_bypass_mode_interval_seconds
         ):
             _LOGGER.debug(
@@ -625,6 +641,12 @@ class TempControlAutomationManager(ExtrasBaseAutomation):
                 settings.min_bypass_mode_interval_seconds,
             )
             desired_mode = prev_mode
+            # Refresh the command timestamp so the bypass safety net
+            # (which allows a 10s window after our commands) does not
+            # falsely trigger while we hold the previous mode.  Without
+            # this, the stale timestamp + a legitimate device-initiated
+            # bypass movement would turn temp_control off.
+            self._last_bypass_command_time[device_id] = now
 
         bypass_cmd = {
             "cooling": "fan_bypass_open",

--- a/docs/phase3_plan.md
+++ b/docs/phase3_plan.md
@@ -14,22 +14,46 @@
 > - **ramses_rf Phase 3/3.25** (PWhite-Eng, issue 639) — **TX Generation
 >   Parity + Transport Layer Decoupling**. Moves command-building and
 >   payload validation out of `ramses_tx` to L7 inside `ramses_rf`.
->   In progress. Will update `SCH_TRAITS_HVAC` to accept `str | list[str]`
->   for binding arrays (our `_bound` as list) and expose
->   `strip_and_map_traits()` as a pre-validation pipeline stage.
+>   In progress. Will bring:
+>   - Native TX builders for 22F7/22B0 (defaults; `_commands` overrides)
+>   - Per-manufacturer HVAC strategy profiles (for TX generation, NOT
+>     device identity)
+>   - `SCH_TRAITS_HVAC` accepts `str | list[str]` for binding arrays
+>   - `strip_and_map_traits()` as pre-validation pipeline (so CLI can
+>     use `_commands` too — currently CLI can't because `_commands` is
+>     stripped by ramses_cc before ramses_rf sees it)
 > - **ramses_rf Phase 3.75** (PWhite-Eng, issue 639) — **Identity
 >   Composition**. Was originally "Builder Pattern" (issue 530), now
 >   reframed as "init and go": devices instantiate with correct, final
 >   roles from schema traits — no runtime `__class__` mutation.
->   `DeviceRole` composition pattern **scrapped** in favor of schema-driven
->   instantiation. Focus is on deprecating `__class__` mutations and
->   routing `1FC9` discoveries into `TopologyChangedEvent`.
 >
-> **Key shift (Jul 17 2026):** PWhite-Eng has scrapped the Builder/Strategy
-> pattern (`DeviceRole`, `supported_commands()`) in favor of "init and go"
-> from schema. This aligns perfectly with our schema-as-SSOT approach.
-> Our `_commands` stays as the user override layer — native TX builders
-> (22F7/22B0) will be defaults, `_commands` overrides them.
+> **Key shift (Jul 17 2026):** PWhite-Eng scrapped the **device identity**
+> part of the Builder pattern (`DeviceRole` composition, active discovery
+> FSM, `supported_commands()` as a strategy method) in favor of "init and
+> go" from schema. The **TX generation** part (native builders for
+> 22F7/22B0, per-manufacturer HVAC strategy profiles) is **still planned**
+> in Phase 3/3.25. These are two different things:
+>
+> | Aspect | Status | Where |
+> |---|---|---|
+> | Device identity (`DeviceRole`, `__class__` replacement) | **Scrapped** — "init and go" from `_class` | Phase 3.75 |
+> | TX generation (native builders, HVAC strategy profiles) | **Still planned** | Phase 3/3.25 |
+> | `supported_commands()` as strategy method | **Scrapped** | — |
+> | `strip_and_map_traits()` in ramses_rf | **Still planned** | Phase 3/3.25 |
+> | `_commands` as user override | **Confirmed** | ramses_cc (now), ramses_rf (Phase 3d) |
+>
+> **`_commands` location:** Currently `_commands` lives in ramses_cc's
+> config entry schema only. ramses_cc strips `_`-prefixed keys before
+> passing the schema to ramses_rf. The CLI (which uses ramses_rf directly)
+> cannot use `_commands` today. Phase 3d will move the strip+map logic to
+> ramses_rf's `strip_and_map_traits()` pipeline so the CLI can also
+> benefit. `_commands` maps to `commands` (no underscore) inside ramses_rf.
+>
+> **`_class` deprecation:** `_class` is **NOT deprecated**. PWhite-Eng's
+> "init and go" approach *uses* `_class` from the schema to instantiate
+> devices with the correct class. silverailscolo's longer-term vision
+> (manufacturer+model+revision from 10E0) is a future enhancement, not a
+> replacement.
 
 ---
 
@@ -189,12 +213,12 @@ in `known_list` (which is being deprecated).
 <a id="pwhite-engs-ramses_rf-phase-3"></a>
 ## PWhite-Eng's ramses_rf Phase 3 (TX Generation + Identity Composition)
 
-> **Updated Jul 17 2026:** The Builder/Strategy pattern (issue 530) has
-> been **scrapped**. PWhite-Eng confirmed in ramses_rf issue 836 that
-> the `DeviceRole` composition pattern and active discovery FSM are no
-> longer planned. Instead, "init and go" — devices instantiate with
-> correct, final roles from schema traits. This aligns perfectly with
-> our schema-as-SSOT approach.
+> **Updated Jul 17 2026:** PWhite-Eng scrapped the **device identity**
+> part of the Builder pattern (`DeviceRole` composition, active discovery
+> FSM, `supported_commands()` as a strategy method) in favor of "init and
+> go" from schema. The **TX generation** part (native builders for
+> 22F7/22B0, per-manufacturer HVAC strategy profiles) is **still planned**
+> in Phase 3/3.25. These are two different things — don't conflate them.
 
 From ramses_rf issue 639 (master roadmap), issue 836, and ramses_cc issue 809:
 
@@ -204,28 +228,41 @@ Moves the entire command-building and payload validation stack out of
 `ramses_tx` and elevates it to L7 inside `ramses_rf`. This is where
 native builders for `22F7` (bypass), `22B0` (calendar), etc. will live.
 
+**What's still planned (TX generation side):**
+- Native TX builders for standard codes (22F7 bypass, 22B0 calendar)
+  → these become **defaults**; `_commands` overrides them
+- Per-manufacturer HVAC strategy profiles (how to build packets for
+  specific manufacturers) — NOT device identity, just TX generation
+- `SCH_TRAITS_HVAC` accepts `str | list[str]` for binding arrays
+  → our `_bound` as list works without strip+map workaround
+- `strip_and_map_traits()` as pre-validation pipeline in ramses_rf
+  → CLI can use `_commands` too (currently can't — stripped by ramses_cc)
+
 **Relevance to ramses_cc:**
 - Native TX builders become the **default** write pathway for standard
   commands. Our `_commands` stays as the **authoritative user override**
   layer — if a user defines `bypass_open` in `_commands`, it overrides
   the native builder.
-- PWhite-Eng will update `SCH_TRAITS_HVAC` to natively accept `str | list[str]`
-  for binding arrays — this means our `_bound` as list will work without
-  the strip+map workaround.
-- PWhite-Eng will expose `strip_and_map_traits()` as a pre-validation
-  pipeline stage inside ramses_rf — this is our Option B! The CLI will
-  benefit immediately, and ramses_cc can eventually stop stripping `_`
-  keys itself.
+- `_commands` currently lives in ramses_cc only (stripped before
+  ramses_rf sees it). Phase 3d moves strip+map to ramses_rf so CLI
+  can also use `_commands` (mapped to `commands` without underscore).
+- `_class` is **NOT deprecated** — "init and go" uses `_class` from
+  schema to instantiate devices with the correct class.
 
 ### ramses_rf Phase 3.75: Identity Composition (was "Builder Pattern")
 
 Originally issue 530 proposed a Builder/Strategy pattern with
-`DeviceRole` composition and `supported_commands()`. This has been
-**scrapped** (Jul 17 2026).
+`DeviceRole` composition and `supported_commands()`. The **device
+identity** part has been **scrapped** (Jul 17 2026).
+
+**What's scrapped (device identity side):**
+- `DeviceRole` composition pattern (replacing `__class__` mutation)
+- Active discovery FSM (probing to discover device type)
+- `supported_commands()` as a strategy method
 
 **New approach — "init and go":**
 - Devices instantiate with their correct, final roles derived directly
-  from the schema traits — no runtime `__class__` mutation.
+  from the schema traits (`_class`) — no runtime `__class__` mutation.
 - Legacy `__class__` mutations will be deprecated and removed.
 - Newly discovered passive bounds (like `1FC9` payloads) are routed
   directly into a `TopologyChangedEvent` so the consumer (ramses_cc)
@@ -234,12 +271,13 @@ Originally issue 530 proposed a Builder/Strategy pattern with
 **Relevance to ramses_cc:**
 - Our schema-as-SSOT approach already delivers this: when the schema
   changes, we tear down and rebuild with correct classes from `_class`.
-- No `_class` deprecation needed — `_class` stays as the schema-driven
-  identity trait. The future "manufacturer+model+revision+options"
-  idea (silverailscolo) is a longer-term enhancement, not a replacement.
-- `_commands` does NOT move to `supported_commands()` on strategies —
-  that concept is gone. `_commands` stays as the user override layer
-  on schema entries.
+- `_class` stays as the schema-driven identity trait — NOT deprecated.
+  silverailscolo's longer-term vision (manufacturer+model+revision from
+  10E0) is a future enhancement, not a replacement.
+- `_commands` stays as the user override layer on schema entries —
+  it does NOT move to `supported_commands()` on strategies (that
+  concept is gone). But native TX builders (Phase 3/3.25) will provide
+  defaults for standard codes.
 
 ### silverailscolo's question (issue 836, Jul 17 2026)
 
@@ -582,17 +620,17 @@ until native TX builders land. See `phase3b_fan_commands_design.md` for full des
 
 These items were originally part of Phase 3b in the initial plan, but were
 split out because they depend on ramses_rf changes. Phase 3b (commands on
-FAN) shipped without them. The Builder/Strategy pattern dependency is gone
-— these items now depend on the TX generation and `strip_and_map_traits`
-work in ramses_rf Phase 3/3.25.
+FAN) shipped without them. The device identity Builder (`DeviceRole`) is
+scrapped, but TX generation builders (native 22F7/22B0, HVAC strategy
+profiles) and `strip_and_map_traits()` are still planned in Phase 3/3.25.
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 3d.1 | ~~Coordinate strategy key names~~ — Builder/Strategy scrapped, no strategy keys needed | N/A |
-| 3d.2 | ~~Map `_class` to Builder strategy names~~ — `_class` stays as schema identity trait | N/A |
+| 3d.1 | Coordinate TX strategy profile key names with PWhite-Eng (per-manufacturer TX profiles, NOT device identity) | TODO |
+| 3d.2 | `_class` stays as schema identity trait — no mapping to strategy names needed (DeviceRole scrapped) | N/A |
 | 3d.3 | Stop stripping `_` keys when ramses_rf accepts them natively (via `strip_and_map_traits()` pipeline) | TODO |
 | 3d.4 | Verify `_bound` as `str \| list[str]` works with updated `SCH_TRAITS_HVAC` | TODO |
-| 3d.5 | Move strip+map pipeline to ramses_rf (so CLI also benefits) | TODO |
+| 3d.5 | Move strip+map pipeline to ramses_rf (so CLI can also use `_commands` → `commands`) | TODO |
 | 3d.6 | Verify native TX builders (22F7/22B0) work as defaults, `_commands` overrides them | TODO |
 
 ### Phase 3c: Flagging mismatches (silverailscolo's concern)
@@ -808,10 +846,12 @@ Before runtime migration, save state as YAML to
 | Jul 2026 | Phase 3b: both REM and FAN get `remote` entities | REM entity (`remote.32_153001`) kept for backward compat — existing automations keep working. FAN entity (`remote.30_160000`) is the new primary. |
 | Jul 2026 | Phase 3b: runtime migration, no store version bump (same as 3a) | `_migrate_rem_commands_to_fan` copies REM `_commands` to FAN as dict templates on every save cycle. REM entries NOT deleted (downgrade safety). |
 | Jul 2026 | Phase 3b: split Builder alignment items to Phase 3d | Original 3b items 3b.1/3b.2/3b.4/3b.5 (strategy keys, `_class` mapping, stop stripping `_` keys, Builder testing) depend on issue 530 — deferred to Phase 3d. |
-| Jul 17 2026 | Builder/Strategy pattern scrapped (PWhite-Eng, issue 836) | `DeviceRole` composition and active discovery FSM scrapped in favor of "init and go" from schema. Devices instantiate with correct roles from schema traits — no runtime `__class__` mutation. Aligns with our schema-as-SSOT approach. |
-| Jul 17 2026 | ramses_rf Phase 3 terminology updated | Was "issue 530 Phase 3 (Builder Pattern)", now: Phase 3/3.25 = TX Generation Parity + Transport Decoupling; Phase 3.75 = Identity Composition (deprecate `__class__`). PWhite-Eng will update `SCH_TRAITS_HVAC` for `str \| list[str]` bindings and expose `strip_and_map_traits()` pipeline. |
-| Jul 17 2026 | Phase 3d re-scoped | Items 3d.1 (strategy key names) and 3d.2 (`_class` → strategy mapping) marked N/A — Builder/Strategy scrapped. New items: 3d.4 (`_bound` as list in `SCH_TRAITS_HVAC`), 3d.6 (verify native TX builders as defaults). |
-| Jul 17 2026 | `_commands` confirmed as user override layer | PWhite-Eng confirmed: native TX builders (22F7/22B0) = defaults, `_commands` = authoritative user override. No `supported_commands()` on strategies — that concept is gone. |
+| Jul 17 2026 | Device identity Builder scrapped (PWhite-Eng, issue 836) | `DeviceRole` composition and active discovery FSM scrapped in favor of "init and go" from schema. Devices instantiate with correct roles from `_class` trait — no runtime `__class__` mutation. TX generation builders (native 22F7/22B0, HVAC strategy profiles) still planned in Phase 3/3.25. |
+| Jul 17 2026 | ramses_rf Phase 3 terminology updated | Was "issue 530 Phase 3 (Builder Pattern)", now: Phase 3/3.25 = TX Generation Parity (still planned); Phase 3.75 = Identity Composition ("init and go", deprecate `__class__`). |
+| Jul 17 2026 | Phase 3d re-scoped | 3d.2 (`_class` → strategy mapping) marked N/A — DeviceRole scrapped, `_class` stays. 3d.1 re-scoped to TX strategy profile key names (still planned). New: 3d.4, 3d.6. |
+| Jul 17 2026 | `_commands` confirmed as user override layer | PWhite-Eng confirmed: native TX builders (22F7/22B0) = defaults, `_commands` = authoritative user override. `supported_commands()` as strategy method scrapped, but native TX builders still planned. |
+| Jul 17 2026 | `_commands` currently ramses_cc-only | `_commands` stripped by ramses_cc before ramses_rf sees it. CLI can't use it today. Phase 3d: `strip_and_map_traits()` in ramses_rf maps `_commands` → `commands` so CLI benefits too. |
+| Jul 17 2026 | `_class` NOT deprecated | "init and go" uses `_class` from schema to instantiate devices. silverailscolo's manufacturer+model+revision idea is a future enhancement, not a replacement. |
 
 ---
 

--- a/docs/phase3_plan.md
+++ b/docs/phase3_plan.md
@@ -635,18 +635,55 @@ profiles) and `strip_and_map_traits()` are still planned in Phase 3/3.25.
 
 ### Phase 3c: Flagging mismatches (silverailscolo's concern)
 
-**Can ship independently.**
+**Can ship independently. ramses_cc-only — no ramses_rf dependency.**
 
-Class mismatch detection already exists at `coordinator.py:722-725` via
-`discovery_manager.check_class_mismatches(schema)` — it logs warnings
-when the user's `_class` override differs from what discovery detected.
-Phase 3c extends this to surface the mismatch in the UI.
+Phase 3c extends the existing class mismatch detection to surface
+mismatches proactively in the UI, and adds three new mismatch types.
+
+#### What was already done (before Phase 3c branch)
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 3c.1 | Log warning when user `_class` override differs from detected | DONE (coordinator.py:722-725) |
-| 3c.2 | Show mismatch flag in config flow review step | TODO |
+| 3c.1 | Log warning when user `_class` override differs from detected | DONE |
+| 3c.2 | Show class mismatch in config flow review step (with Update/Keep) | DONE |
 | 3c.3 | Still apply override (don't leave device broken) | DONE (schema is authoritative) |
+
+#### New in Phase 3c branch (`feature/phase3c-flagging`)
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 3c.4 | Persistent notification for all mismatch types | DONE |
+| 3c.5 | Diagnostic entity attributes (`class_mismatch`, `bound_mismatch`, `missing_class`, `orphaned`) | DONE |
+| 3c.6 | `_bound` mismatch detection (schema `_bound` vs scan `bound_to`) | DONE |
+| 3c.7 | Missing `_class` detection (scan has `likely_type` but schema has no `_class`) | DONE |
+| 3c.8 | Orphaned device detection (in schema but not seen by scan for N days) | DONE |
+| 3c.9 | Unified `check_all_mismatches()` called from coordinator checkpoint | DONE |
+| 3c.10 | Unit tests: 22 new (6 bound, 5 missing_class, 7 orphaned, 4 unified) | DONE |
+
+#### Implementation details
+
+**Persistent notification** (`discovery.py`):
+- Separate notification ID: `ramses_cc_discovery_mismatches`
+- Shows counts + per-device details for each mismatch type
+- Auto-dismissed when all mismatches are resolved
+- Called from `check_all_mismatches()` during the periodic checkpoint
+
+**Entity attributes** (`entity.py`):
+- `RamsesEntity.extra_state_attributes` checks `discovery_manager._metadata`
+- Only adds attributes when the value is a non-empty string (defensive)
+- Visible in Developer Tools → States for any entity whose device has a flag
+
+**New `DeviceMetadata` fields**:
+- `bound_mismatch: str | None` — "schema=X, discovery=Y"
+- `missing_class: str | None` — "discovery=FAN" (scan has a type, schema doesn't)
+- `orphaned: str | None` — "not seen by scan" or "last seen {date} (>N days)"
+- All serialized/deserialized in `to_dict()` / `from_dict()`
+
+**Orphaned detection**:
+- Uses `LOST_DEVICE_THRESHOLD_DAYS` (default 7) — same as lost device detection
+- Skips HGI (18:), structural keys (`main_tcs`, `_owner`), and NEW devices
+- Checks `last_seen` from scan engine if device is in scan
+- If device is in schema but not in scan at all, flags as orphaned
 
 ---
 

--- a/docs/phase3b_fan_commands_design.md
+++ b/docs/phase3b_fan_commands_design.md
@@ -16,10 +16,11 @@
 >   Composition. Was "Builder Pattern" (issue 530), now "init and go"
 >   from schema. `DeviceRole` and `supported_commands()` scrapped.
 >
-> **Key shift (Jul 17 2026):** Builder/Strategy pattern scrapped. No
-> `supported_commands()` on strategies. `_commands` stays as user override
-> layer. Native TX builders (when they land in Phase 3/3.25) become
-> defaults; `_commands` overrides them.
+> **Key shift (Jul 17 2026):** Device identity Builder scrapped
+> (`DeviceRole`, `supported_commands()` as strategy method). "init and go"
+> from schema `_class`. TX generation builders (native 22F7/22B0, HVAC
+> strategy profiles) still planned in Phase 3/3.25. `_commands` stays as
+> user override layer. `_class` NOT deprecated.
 
 ## Contents
 
@@ -613,12 +614,12 @@ Called in all 3 branches of `async_save_client_state`:
 
 ## Alignment with ramses_rf
 
-> **Updated Jul 17 2026:** The Builder/Strategy pattern (issue 530) has
-> been **scrapped**. PWhite-Eng confirmed in ramses_rf issue 836 that
-> `DeviceRole` composition, `supported_commands()`, and dynamic
-> strategies are no longer planned. Instead, "init and go" — devices
-> instantiate with correct roles from schema traits. This aligns
-> perfectly with our schema-as-SSOT approach.
+> **Updated Jul 17 2026:** PWhite-Eng scrapped the **device identity**
+> part of the Builder pattern (`DeviceRole`, `supported_commands()` as
+> strategy method, active discovery FSM). "init and go" — devices
+> instantiate with correct roles from schema `_class`. The **TX
+> generation** part (native builders for 22F7/22B0, per-manufacturer
+> HVAC strategy profiles) is **still planned** in Phase 3/3.25.
 
 This design aligns with PWhite-Eng's architectural refactor (issue 639)
 and the Discussion 191 consensus. Our Phase 3b is ramses_cc-only and does

--- a/docs/schema_architecture.md
+++ b/docs/schema_architecture.md
@@ -15,8 +15,11 @@
 >   from schema. `DeviceRole` composition scrapped. Deprecate `__class__`
 >   mutations.
 >
-> **Key shift (Jul 17 2026):** Builder/Strategy pattern scrapped in favor
-> of "init and go" from schema. `_commands` stays as user override layer.
+> **Key shift (Jul 17 2026):** Device identity Builder (`DeviceRole`,
+> `supported_commands()`) scrapped in favor of "init and go" from schema
+> `_class`. TX generation builders (native 22F7/22B0, HVAC strategy
+> profiles) still planned in Phase 3/3.25. `_commands` stays as user
+> override layer. `_class` NOT deprecated.
 
 <a id="chapters"></a>
 ## Chapters

--- a/tests/features/temp_control/test_temp_control_automation.py
+++ b/tests/features/temp_control/test_temp_control_automation.py
@@ -356,6 +356,96 @@ class TestTempControlMinInterval:
         assert automation_manager._mode["32:153289"] == "cooling"
 
     @pytest.mark.asyncio
+    async def test_min_interval_does_not_block_transition_to_idle(
+        self, automation_manager
+    ):
+        """Transitions from cooling/heating_retention to idle are never
+        suppressed, even within the min interval.
+
+        Suppressing cooling→idle keeps temp_control in an active forcing
+        mode with a stale command timestamp.  When the device then
+        legitimately moves the bypass on its own (conditions changed),
+        the bypass safety net falsely detects a manual override and turns
+        temp_control off — see issue 106.
+        """
+        import time
+
+        automation_manager._mode["32:153289"] = "cooling"
+        automation_manager._last_bypass_change["32:153289"] = (
+            time.time() - 10  # only 10s ago, well within 180s
+        )
+
+        # Conditions no longer warrant cooling: outdoor warmer than indoor
+        states = make_entity_states(
+            indoor_temp=22.0,
+            outdoor_temp=24.0,  # outdoor warmer → no free cooling
+            comfort_temp=21.0,
+        )
+        await automation_manager._process_automation_logic("32:153289", states)
+
+        # Should transition to idle immediately (not suppressed)
+        assert automation_manager._mode["32:153289"] == "idle"
+        # Should send fan_bypass_auto to release bypass control
+        automation_manager.ramses_commands.send_command.assert_called_with(
+            "32:153289", "fan_bypass_auto"
+        )
+
+    @pytest.mark.asyncio
+    async def test_min_interval_does_not_block_transition_from_idle(
+        self, automation_manager
+    ):
+        """Transitions from idle to cooling/heating_retention are not
+        suppressed (entering an active mode is a new decision, not a
+        reversal of a recent one)."""
+        import time
+
+        automation_manager._mode["32:153289"] = "idle"
+        automation_manager._last_bypass_change["32:153289"] = (
+            time.time() - 10  # only 10s ago
+        )
+
+        # Conditions now warrant cooling
+        states = make_entity_states(
+            indoor_temp=24.0,
+            outdoor_temp=18.0,
+            comfort_temp=21.0,
+        )
+        await automation_manager._process_automation_logic("32:153289", states)
+
+        assert automation_manager._mode["32:153289"] == "cooling"
+
+    @pytest.mark.asyncio
+    async def test_min_interval_refreshes_command_time_when_suppressing(
+        self, automation_manager
+    ):
+        """When an active→active transition is suppressed, the command
+        timestamp is refreshed so the bypass safety net does not falsely
+        trigger on legitimate device-initiated bypass movements."""
+        import time
+
+        automation_manager._mode["32:153289"] = "cooling"
+        automation_manager._last_bypass_change["32:153289"] = (
+            time.time() - 10  # only 10s ago, within 180s
+        )
+        automation_manager._last_bypass_command_time["32:153289"] = (
+            time.time() - 60  # stale command timestamp
+        )
+
+        # Conditions now warrant heating_retention (indoor dropped)
+        states = make_entity_states(
+            indoor_temp=18.0,
+            comfort_temp=21.0,
+        )
+        await automation_manager._process_automation_logic("32:153289", states)
+
+        # Mode should stay cooling (suppressed)
+        assert automation_manager._mode["32:153289"] == "cooling"
+        # Command timestamp should be refreshed (not stale anymore)
+        assert (
+            time.time() - automation_manager._last_bypass_command_time["32:153289"] < 5
+        )
+
+    @pytest.mark.asyncio
     async def test_min_interval_allows_after_elapsed(self, automation_manager):
         """When min interval has elapsed, mode change is allowed."""
         import time
@@ -627,6 +717,53 @@ class TestTempControlBypassSafetyNet:
             )
 
         mock_super.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_suppressed_mode_does_not_cause_false_safety_net(
+        self, automation_manager
+    ):
+        """Regression test for issue 106: when a cooling→heating_retention
+        transition is suppressed by min_bypass_mode_interval_seconds, the
+        command timestamp is refreshed so a subsequent bypass position
+        change does not falsely trigger the safety net and turn
+        temp_control off.
+
+        Before the fix, the suppression kept temp_control in cooling mode
+        with a stale _last_bypass_command_time.  When the device moved the
+        bypass on its own, the safety net (10s window) fired and turned
+        temp_control off — "Temp control turned off after cooling".
+        """
+        import time
+
+        hass = automation_manager.hass
+        switch_state = MagicMock()
+        switch_state.state = "on"
+        hass.states.get = MagicMock(return_value=switch_state)
+        hass.services.async_call = AsyncMock()
+
+        # Simulate: temp_control in cooling, suppression just happened
+        # (command timestamp was refreshed by the suppression logic)
+        automation_manager._mode["32:153289"] = "cooling"
+        automation_manager._last_bypass_command_time["32:153289"] = (
+            time.time() - 2  # recent — refreshed by suppression
+        )
+
+        old_state = MagicMock()
+        new_state = MagicMock()
+
+        with patch.object(
+            type(automation_manager).__mro__[1],
+            "_async_handle_state_change",
+            new_callable=AsyncMock,
+        ):
+            await automation_manager._async_handle_state_change(
+                "binary_sensor.32_153289_bypass_position",
+                old_state,
+                new_state,
+            )
+
+        # Safety net must NOT fire because command timestamp is recent
+        hass.services.async_call.assert_not_called()
 
 
 class TestTempControlPerAreaEvaluation:

--- a/tools/ha_sim_test.py
+++ b/tools/ha_sim_test.py
@@ -185,6 +185,11 @@ EXPECTED_WARNINGS: list[str] = [
     # ramses_cc: migration warning for known_list devices not in schema
     # (expected after profile reload)
     "known_list devices not in schema",
+    # ramses_cc: Phase 3c mismatch warnings (expected in recipe 24/26)
+    "class mismatches between discovery and schema",
+    "bound mismatches between discovery and schema",
+    "have no _class but discovery has a suggestion",
+    "appear orphaned",
     # ramses_cc: bound device not found during early init (FAN not yet active)
     "Bound device",
     "not found for FAN",
@@ -676,6 +681,35 @@ def wait(seconds: int, msg: str = "") -> None:
     print(f"  Waiting {seconds}s {msg}...", end="", flush=True)
     time.sleep(seconds)
     print(" done")
+
+
+def get_persistent_notifications(token: str) -> list:
+    """Get all persistent notifications from the HA API.
+
+    Returns a list of notification dicts (notification_id, title, message).
+    """
+    req = urllib.request.Request(
+        HA_URL + "/api/states",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    states = json.loads(urllib.request.urlopen(req).read())
+    # Persistent notifications appear as states with entity_id starting
+    # with "persistent_notification."
+    return [s for s in states if s["entity_id"].startswith("persistent_notification.")]
+
+
+def get_entity_attributes(token: str, device_id: str, prefix: str = "") -> dict:
+    """Get the state attributes for an entity associated with a device.
+
+    :param device_id: The ramses device ID (e.g. "32:150000")
+    :param prefix: Optional entity-type prefix (e.g. "fan_", "remote_")
+    :return: The attributes dict, or empty dict if entity not found.
+    """
+    entities = get_entities(token)
+    entity = find_entity_for_device(entities, device_id, prefix=prefix)
+    if entity is None:
+        return {}
+    return entity.get("attributes", {})
 
 
 # ---------------------------------------------------------------------------
@@ -2744,6 +2778,158 @@ async def main() -> None:
             schema_keys_r20[0] == "_owner",
             f"first key={schema_keys_r20[0]}",
         )
+
+    # =====================================================================
+    # RECIPE 24: Phase 3c — class mismatch flagging
+    # =====================================================================
+    log_section("Recipe 24: Phase 3c — class mismatch flagging")
+
+    # This recipe tests that when the schema has a wrong _class for a
+    # device, the mismatch is detected and surfaced as:
+    # 1. A persistent notification
+    # 2. An entity attribute (class_mismatch)
+    #
+    # We load a profile where the FAN (32:150000) has _class="DIS"
+    # instead of "FAN", then check that the mismatch is flagged.
+
+    mismatch_schema = dict(MIXED_SCHEMA)
+    mismatch_schema[FAN] = {
+        **mismatch_schema.get(FAN, {}),
+        "_class": "DIS",  # wrong class — should be FAN
+    }
+    mismatch_yaml = _mixed_yaml(mismatch_schema)
+    await load_profile_yaml(token, mismatch_yaml, speed=0.01)
+    wait(5, "for profile reload + entity creation")
+
+    # Force a sync cycle to trigger mismatch detection
+    try:
+        call_service(token, "ramses_cc", "sync_topology")
+    except RuntimeError:
+        pass
+    wait(5, "for mismatch detection")
+    try:
+        call_service(token, "ramses_cc", "force_update")
+    except RuntimeError:
+        pass
+    wait(3, "for save")
+
+    # Check 1: FAN entity should have class_mismatch attribute
+    fan_attrs = get_entity_attributes(token, FAN, prefix="fan_")
+    if not fan_attrs:
+        # FAN entity might be under a different prefix
+        fan_attrs = get_entity_attributes(token, FAN, prefix="remote_")
+    check(
+        "FAN entity has class_mismatch attribute",
+        "class_mismatch" in fan_attrs,
+        f"attrs keys={list(fan_attrs.keys())[:15]}",
+    )
+    if "class_mismatch" in fan_attrs:
+        check(
+            "class_mismatch shows schema=DIS, discovery=FAN",
+            "DIS" in fan_attrs["class_mismatch"]
+            and "FAN" in fan_attrs["class_mismatch"],
+            f"class_mismatch={fan_attrs['class_mismatch']}",
+        )
+
+    # Check 2: Persistent notification should exist
+    notifications = get_persistent_notifications(token)
+    mismatch_notif = [
+        n
+        for n in notifications
+        if "mismatch" in n.get("attributes", {}).get("title", "").lower()
+        or "mismatch" in n.get("state", "").lower()
+    ]
+    check(
+        "Persistent notification for mismatches exists",
+        len(mismatch_notif) > 0,
+        f"notifications={[n.get('entity_id') for n in notifications]}",
+    )
+
+    # =====================================================================
+    # RECIPE 25: Phase 3c — fix mismatch, notification dismissed
+    # =====================================================================
+    log_section("Recipe 25: Phase 3c — fix mismatch, notification dismissed")
+
+    # Reload with correct _class — mismatch should clear
+    fixed_yaml = _mixed_yaml()  # default MIXED_SCHEMA has no _class override
+    await load_profile_yaml(token, fixed_yaml, speed=0.01)
+    wait(5, "for profile reload")
+
+    try:
+        call_service(token, "ramses_cc", "sync_topology")
+    except RuntimeError:
+        pass
+    wait(5, "for mismatch recheck")
+    try:
+        call_service(token, "ramses_cc", "force_update")
+    except RuntimeError:
+        pass
+    wait(3, "for save")
+
+    # Check 1: FAN entity should NOT have class_mismatch attribute
+    fan_attrs_fixed = get_entity_attributes(token, FAN, prefix="fan_")
+    if not fan_attrs_fixed:
+        fan_attrs_fixed = get_entity_attributes(token, FAN, prefix="remote_")
+    check(
+        "FAN entity has no class_mismatch after fix",
+        "class_mismatch" not in fan_attrs_fixed,
+        f"class_mismatch={fan_attrs_fixed.get('class_mismatch')}",
+    )
+
+    # Check 2: Mismatch notification should be dismissed
+    notifications_after = get_persistent_notifications(token)
+    mismatch_notif_after = [
+        n
+        for n in notifications_after
+        if "mismatch" in n.get("attributes", {}).get("title", "").lower()
+        or "mismatch" in n.get("state", "").lower()
+    ]
+    check(
+        "Mismatch notification dismissed after fix",
+        len(mismatch_notif_after) == 0,
+        f"remaining={[n.get('entity_id') for n in mismatch_notif_after]}",
+    )
+
+    # =====================================================================
+    # RECIPE 26: Phase 3c — missing _class detection
+    # =====================================================================
+    log_section("Recipe 26: Phase 3c — missing _class detection")
+
+    # Load a profile where the FAN has no _class at all — the scan engine
+    # knows it's a FAN (from 31D9 packets) but the schema has no _class.
+    # This should trigger a missing_class flag.
+    no_class_schema = dict(MIXED_SCHEMA)
+    # Ensure FAN entry exists but has no _class
+    no_class_schema[FAN] = {
+        "remotes": [REM],
+        "sensors": [CO2],
+    }
+    no_class_yaml = _mixed_yaml(no_class_schema)
+    await load_profile_yaml(token, no_class_yaml, speed=0.01)
+    wait(5, "for profile reload")
+
+    try:
+        call_service(token, "ramses_cc", "sync_topology")
+    except RuntimeError:
+        pass
+    wait(5, "for missing_class detection")
+    try:
+        call_service(token, "ramses_cc", "force_update")
+    except RuntimeError:
+        pass
+    wait(3, "for save")
+
+    # Check: FAN entity should have missing_class attribute
+    fan_attrs_nc = get_entity_attributes(token, FAN, prefix="fan_")
+    if not fan_attrs_nc:
+        fan_attrs_nc = get_entity_attributes(token, FAN, prefix="remote_")
+    # Note: this may not trigger if the scan engine hasn't classified
+    # the FAN yet — log what we got for debugging
+    check(
+        "FAN entity has missing_class attribute",
+        "missing_class" in fan_attrs_nc,
+        f"attrs keys={list(fan_attrs_nc.keys())[:15]}",
+    )
 
     # =====================================================================
     # LOG REPORT: Collect and analyse ha-sim logs from the entire test run

--- a/tools/ha_sim_test.py
+++ b/tools/ha_sim_test.py
@@ -2814,10 +2814,11 @@ async def main() -> None:
     wait(3, "for save")
 
     # Check 1: FAN entity should have class_mismatch attribute
-    fan_attrs = get_entity_attributes(token, FAN, prefix="fan_")
+    # The remote entity (remote.32_150000) inherits from RamsesEntity
+    # which surfaces mismatch flags. The sensor entity may not.
+    fan_attrs = get_entity_attributes(token, FAN, prefix="remote_")
     if not fan_attrs:
-        # FAN entity might be under a different prefix
-        fan_attrs = get_entity_attributes(token, FAN, prefix="remote_")
+        fan_attrs = get_entity_attributes(token, FAN, prefix="fan_")
     check(
         "FAN entity has class_mismatch attribute",
         "class_mismatch" in fan_attrs,
@@ -2867,9 +2868,9 @@ async def main() -> None:
     wait(3, "for save")
 
     # Check 1: FAN entity should NOT have class_mismatch attribute
-    fan_attrs_fixed = get_entity_attributes(token, FAN, prefix="fan_")
+    fan_attrs_fixed = get_entity_attributes(token, FAN, prefix="remote_")
     if not fan_attrs_fixed:
-        fan_attrs_fixed = get_entity_attributes(token, FAN, prefix="remote_")
+        fan_attrs_fixed = get_entity_attributes(token, FAN, prefix="fan_")
     check(
         "FAN entity has no class_mismatch after fix",
         "class_mismatch" not in fan_attrs_fixed,
@@ -2920,9 +2921,9 @@ async def main() -> None:
     wait(3, "for save")
 
     # Check: FAN entity should have missing_class attribute
-    fan_attrs_nc = get_entity_attributes(token, FAN, prefix="fan_")
+    fan_attrs_nc = get_entity_attributes(token, FAN, prefix="remote_")
     if not fan_attrs_nc:
-        fan_attrs_nc = get_entity_attributes(token, FAN, prefix="remote_")
+        fan_attrs_nc = get_entity_attributes(token, FAN, prefix="fan_")
     # Note: this may not trigger if the scan engine hasn't classified
     # the FAN yet — log what we got for debugging
     check(


### PR DESCRIPTION
## Summary

Fixes issue 106 — "Temp control turned off after cooling". Also addresses the Tweakers.net report (studiostevus, 2026-07-17) where pressing the temp control button had no effect, bypass position stayed 'off', and the device went offline.

### Root cause

Interaction between two mechanisms in `temp_control/automation.py`:

1. **`min_bypass_mode_interval_seconds` suppression** — prevents rapid mode changes to avoid bypass damper oscillation
2. **Bypass safety net** — turns temp_control OFF when an "external" bypass position change is detected while temp_control is actively forcing a bypass state (cooling/heating_retention)

Failure sequence:
1. Temp_control enters **cooling** → sends `fan_bypass_open`, records command timestamp T0
2. Conditions change (outdoor warms above indoor) → decision logic wants **idle**, but suppression blocks `cooling→idle` (only 30s < 180s elapsed). Mode stays `cooling`, **no command sent**, command timestamp goes stale
3. FAN device legitimately closes the bypass on its own (no cooling benefit) → `bypass_position` changes
4. Safety net sees: mode=`cooling` (actively forcing) + stale timestamp (>10s) → **falsely turns temp_control OFF**

### Fix

- **Only suppress active→active transitions** (`cooling↔heating_retention`). Transitions to/from `idle` are always allowed: releasing bypass control (`fan_bypass_auto`) is not oscillation, and entering an active mode from idle is a new decision, not a reversal.
- **Refresh `_last_bypass_command_time` when suppressing** an active→active transition, so the safety net's 10s window is reset and legitimate device-initiated bypass movements during the hold do not falsely trigger.

### Tests added (4)

- `test_min_interval_does_not_block_transition_to_idle` — cooling→idle not suppressed within min interval
- `test_min_interval_does_not_block_transition_from_idle` — idle→cooling not suppressed
- `test_min_interval_refreshes_command_time_when_suppressing` — suppression refreshes command timestamp
- `test_suppressed_mode_does_not_cause_false_safety_net` — full regression: suppressed mode + bypass change does NOT turn temp_control off

#### Test plan

- [x] `pytest tests/features/temp_control/` — 204 passed
- [x] `ruff check` + `ruff format` — clean
- [x] `mypy` — clean
- [x] pre-commit hooks pass