### PR TITLE
fix: send 2411/4B bypass param alongside 22F7, relax REM dropdown filter

### DIFF
--- a/custom_components/ramses_extras/features/sensor_control/config_flow.py
+++ b/custom_components/ramses_extras/features/sensor_control/config_flow.py
@@ -2113,17 +2113,23 @@ def _get_rem_device_options(hass: HomeAssistant) -> list[selector.SelectOptionDi
     domain_data = hass.data.get(DOMAIN, {})
     devices = domain_data.get("devices", [])
 
+    # HVAC remote/display (REM/DIS) prefixes.  These devices are often not
+    # yet promoted to the REM/DIS class by ramses_rf (e.g. right after a
+    # restart, or when the binding/1FC9 handshake hasn't completed), so they
+    # appear as plain string devices.  The whitelist below covers the known
+    # REM/DIS prefixes we have seen in the wild:
+    #   21 - Orcon 15RF / Display (e.g. 21:800000, 21:800060)
+    #   37 - Orcon/Vasco REM (e.g. 37:155617)
+    #   18, 22, 29, 30 - other HVAC remote prefixes previously matched
+    # See ramses_rf `devices/hvac_remotes.py::_REMOTES` for the Orcon models.
+    _rem_prefixes = ("18", "21", "22", "29", "30", "37")
+
     for device in devices:
         if isinstance(device, str):
-            # For plain string devices, check if it looks like a REM ID
-            # REM IDs are typically 2-digit prefixes like 18, 22, 29, 30
+            # For plain string devices, check if it looks like a REM ID.
+            # REM/DIS IDs are 2-digit prefix + :XXXXXX (>= 9 chars total).
             device_id = str(device).replace("_", ":").strip()
-            if len(device_id) >= 9 and device_id[:2] in (
-                "18",
-                "22",
-                "29",
-                "30",
-            ):
+            if len(device_id) >= 9 and device_id[:2] in _rem_prefixes:
                 add_device_id(device_id)
             continue
 
@@ -2148,9 +2154,21 @@ def _get_rem_device_options(hass: HomeAssistant) -> list[selector.SelectOptionDi
         if hasattr(device, "type"):
             slugs.append(str(device.type))
 
-        # Check if any slug indicates a DIS/REM device
+        # Check if any slug indicates a DIS/REM device.  Include both the
+        # human-friendly names and the canonical ramses_rf DevType slugs:
+        # REM -> "switch", DIS -> "switch_display" (see DEV_TYPE_MAP).
         is_rem = any(
-            slug in ("DIS", "REM", "DIS", "HRC", "remote", "display") for slug in slugs
+            slug
+            in (
+                "DIS",
+                "REM",
+                "HRC",
+                "remote",
+                "display",
+                "switch",
+                "switch_display",
+            )
+            for slug in slugs
         )
 
         if is_rem:

--- a/custom_components/ramses_extras/framework/helpers/ramses_commands.py
+++ b/custom_components/ramses_extras/framework/helpers/ramses_commands.py
@@ -309,6 +309,21 @@ class RamsesCommands:
         error_msg = f"Failed to send fan command '{command}' to device {device_id}"
         return CommandResult(success=False, error_message=error_msg)
 
+    # Mapping of fan_bypass_* commands to the corresponding 2411 parameter
+    # "4B" (Bypass Valve) value used by Orcon and other units that do not
+    # respond to 22F7.  See ramses_rf `_2411_PARAMS_SCHEMA["4B"]`:
+    #   0 = auto, 1 = open, 2 = closed.
+    # We send BOTH the 22F7 packet and the 2411/4B parameter so the bypass
+    # works regardless of which mechanism the FAN implements.  The 2411
+    # send is best-effort: some units lack a bound REM or 2411 support, in
+    # which case the 22F7 leg is still the authoritative one.
+    _BYPASS_2411_PARAM_ID = "4B"
+    _BYPASS_COMMAND_TO_2411_VALUE: dict[str, int] = {
+        "fan_bypass_open": 1,
+        "fan_bypass_close": 2,
+        "fan_bypass_auto": 0,
+    }
+
     async def send_command(
         self,
         device_id: str,
@@ -335,9 +350,49 @@ class RamsesCommands:
             )
 
         # Send command with queuing
-        return await self._device_manager.send_command_to_device(
+        result = await self._device_manager.send_command_to_device(
             device_id, cmd_def, priority, timeout
         )
+
+        # For bypass commands, also send the 2411/4B parameter that some
+        # Orcon/HRC units use instead of (or in addition to) 22F7.  This is
+        # best-effort: failures are logged but never override the primary
+        # 22F7 result, since not every FAN supports 2411 or has a bound REM.
+        param_value = self._BYPASS_COMMAND_TO_2411_VALUE.get(command_name)
+        if param_value is not None:
+            await self._send_bypass_2411_param(device_id, param_value)
+
+        return result
+
+    async def _send_bypass_2411_param(self, device_id: str, value: int) -> None:
+        """Best-effort send of the 2411 bypass-valve parameter (4B).
+
+        Some Orcon HRC units drive the bypass via 2411 param 4B rather than
+        22F7.  We send it alongside the 22F7 bypass command so both unit
+        types are covered.  Any error is logged at debug level only — the
+        22F7 leg is authoritative for the overall command result.
+
+        :param device_id: Target FAN device identifier
+        :param value: 2411/4B value (0=auto, 1=open, 2=closed)
+        """
+        try:
+            param_result = await self.set_fan_param(
+                device_id, self._BYPASS_2411_PARAM_ID, value
+            )
+            if not param_result.success:
+                _LOGGER.debug(
+                    "Best-effort 2411/%s bypass send for %s did not succeed: %s",
+                    self._BYPASS_2411_PARAM_ID,
+                    device_id,
+                    param_result.error_message,
+                )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Best-effort 2411/%s bypass send for %s raised: %s",
+                self._BYPASS_2411_PARAM_ID,
+                device_id,
+                err,
+            )
 
     async def update_fan_params(
         self, device_id: str, from_id: str | None = None

--- a/tests/features/sensor_control/test_sensor_control_config_flow.py
+++ b/tests/features/sensor_control/test_sensor_control_config_flow.py
@@ -1597,6 +1597,54 @@ def test_get_rem_device_options_includes_configured():
     assert "01:999999" not in values
 
 
+def test_get_rem_device_options_includes_orcon_rem_prefixes():
+    """Orcon REM/DIS prefixes (21, 37) must appear even when not promoted.
+
+    Reproduces the Tweakers report from studiostevus: his Orcon HRC REM was
+    not yet classified as REM/DIS by ramses_rf, so it only existed as a plain
+    string device with prefix 21/37.  The dropdown must still surface it.
+    """
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "devices": ["21:800000", "37:155617", "01:999999", "32:153002"],
+            "config_entry": MagicMock(data={}, options={}),
+        }
+    }
+
+    values = [opt["value"] for opt in _get_rem_device_options(hass)]
+    assert "21:800000" in values
+    assert "37:155617" in values
+    # Non-remote prefixes are still excluded
+    assert "01:999999" not in values
+    assert "32:153002" not in values
+
+
+def test_get_rem_device_options_includes_switch_slug_devices():
+    """Devices promoted to REM/DIS expose the canonical ramses_rf slugs
+    "switch" / "switch_display" (DEV_TYPE_MAP), not "REM"/"DIS" literals."""
+    hass = MagicMock()
+
+    class RemDevice:
+        id = "37:155617"
+        slugs = ["switch"]
+
+    class DisDevice:
+        id = "21:800060"
+        slugs = ["switch_display"]
+
+    hass.data = {
+        DOMAIN: {
+            "devices": [RemDevice(), DisDevice()],
+            "config_entry": MagicMock(data={}, options={}),
+        }
+    }
+
+    values = [opt["value"] for opt in _get_rem_device_options(hass)]
+    assert "37:155617" in values
+    assert "21:800060" in values
+
+
 def test_get_area_id_options_from_legacy_reads_rems():
     options = {
         "ramses_extras": {

--- a/tests/framework/helpers/test_ramses_commands.py
+++ b/tests/framework/helpers/test_ramses_commands.py
@@ -43,6 +43,24 @@ def ramses_commands(hass):
                 "payload": "000107",
                 "description": "Low",
             },
+            "fan_bypass_open": {
+                "code": "22F7",
+                "verb": "W",
+                "payload": "00C8EF",
+                "description": "Open bypass",
+            },
+            "fan_bypass_close": {
+                "code": "22F7",
+                "verb": "W",
+                "payload": "0000EF",
+                "description": "Close bypass",
+            },
+            "fan_bypass_auto": {
+                "code": "22F7",
+                "verb": "W",
+                "payload": "00FFEF",
+                "description": "Set bypass to auto mode",
+            },
         }.get(cmd)
         mock_reg.get_registered_commands.return_value = {"fan_high": {}, "fan_low": {}}
         return RamsesCommands(hass)
@@ -164,6 +182,83 @@ class TestRamsesCommands:
 
         assert result.success is True
         ramses_commands._device_manager.send_command_to_device.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_bypass_command_also_sends_2411_param(self, ramses_commands):
+        """fan_bypass_* commands must also send the 2411/4B parameter.
+
+        Some Orcon HRC units drive the bypass via 2411 param 4B rather than
+        22F7, so send_command fires both legs.  The 2411 send is best-effort
+        and must not override the primary 22F7 result.
+        """
+        ramses_commands._device_manager.send_command_to_device = AsyncMock(
+            return_value=CommandResult(success=True)
+        )
+        ramses_commands.set_fan_param = AsyncMock(
+            return_value=CommandResult(success=True)
+        )
+
+        cases = {
+            "fan_bypass_open": 1,
+            "fan_bypass_close": 2,
+            "fan_bypass_auto": 0,
+        }
+        for command_name, expected_value in cases.items():
+            ramses_commands.set_fan_param.reset_mock()
+            result = await ramses_commands.send_command("32_123456", command_name)
+
+            assert result.success is True
+            ramses_commands.set_fan_param.assert_awaited_once_with(
+                "32_123456", "4B", expected_value
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_bypass_command_2411_failure_does_not_fail_command(
+        self, ramses_commands
+    ):
+        """A best-effort 2411/4B failure must not fail the 22F7 bypass send."""
+        ramses_commands._device_manager.send_command_to_device = AsyncMock(
+            return_value=CommandResult(success=True)
+        )
+        ramses_commands.set_fan_param = AsyncMock(
+            return_value=CommandResult(success=False, error_message="broker not found")
+        )
+
+        result = await ramses_commands.send_command("32_123456", "fan_bypass_open")
+
+        # Primary 22F7 result is preserved
+        assert result.success is True
+        ramses_commands.set_fan_param.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_bypass_command_2411_raises_does_not_fail_command(
+        self, ramses_commands
+    ):
+        """An exception from the 2411 leg must not propagate."""
+        ramses_commands._device_manager.send_command_to_device = AsyncMock(
+            return_value=CommandResult(success=True)
+        )
+        ramses_commands.set_fan_param = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await ramses_commands.send_command("32_123456", "fan_bypass_close")
+
+        assert result.success is True
+        ramses_commands.set_fan_param.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_non_bypass_command_does_not_send_2411(self, ramses_commands):
+        """Non-bypass commands must not trigger the 2411/4B leg."""
+        ramses_commands._device_manager.send_command_to_device = AsyncMock(
+            return_value=CommandResult(success=True)
+        )
+        ramses_commands.set_fan_param = AsyncMock(
+            return_value=CommandResult(success=True)
+        )
+
+        result = await ramses_commands.send_command("32_123456", "fan_high")
+
+        assert result.success is True
+        ramses_commands.set_fan_param.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_send_packet_success(self, ramses_commands, hass):


### PR DESCRIPTION
Some Orcon HRC units drive the bypass valve via 2411 parameter 4B (0=auto, 1=open, 2=closed) instead of 22F7 (see ramses_rf _2411_PARAMS_SCHEMA["4B"]).  RamsesCommands.send_command now fires both the 22F7 packet and a best-effort 2411/4B set via the ramses_cc broker, so bypass control works regardless of which mechanism the FAN implements.  The 2411 leg never overrides the primary 22F7 result and swallows errors, since not every FAN supports 2411 or has a bound REM.

Also relax the REM dropdown in sensor_control config_flow:
- add Orcon REM/DIS prefixes 21 (15RF/Display) and 37 (Orcon/Vasco REM) to the plain-string-device whitelist
- add the canonical ramses_rf DevType slugs "switch" (REM) and "switch_display" (DIS) to slug detection, which the old filter missed entirely (it only checked "REM"/"DIS" literals)

Reported by studiostevus on Tweakers (Orcon HRC / WtW topic, message 85756112).