### PR TITLE
fix: rename R34 water_heater recipe to R35 (conflict with BDR re-pare…

### DIFF
--- a/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
@@ -1,4 +1,4 @@
-"""Recipe R34: Water heater DHW CQRS hydration (issue 843)."""
+"""Recipe R35: Water heater DHW CQRS hydration (issue 843)."""
 
 from __future__ import annotations
 
@@ -14,8 +14,8 @@ from ..helpers import (
 )
 
 
-class R34WaterHeaterDhwCqrsHydrationIssue843(Recipe):
-    id = "R34"
+class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
+    id = "R35"
     seq = 360
     title = "Water heater DHW CQRS hydration (issue 843)"
 


### PR DESCRIPTION
…nt R34)

Two recipes were both registered with id='R34', causing ha_sim_test to fail with 'Recipe id R34 already registered'. Renamed the water heater DHW CQRS hydration recipe (issue 843) from R34 to R35.