### PR TITLE
fix: replace insecure tempfile.mktemp with NamedTemporaryFile (code-scanning alert 8)

### DIFF
--- a/tools/ha_sim_test/recipes/r59_phase4_cleanup_stale_known_list.py
+++ b/tools/ha_sim_test/recipes/r59_phase4_cleanup_stale_known_list.py
@@ -99,9 +99,9 @@ class R59Phase4CleanupStaleKnownList(Recipe):
         import os
         import tempfile
 
-        tmp_path = tempfile.mktemp(suffix=".json")
-        with open(tmp_path, "w") as f:
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
             json.dump(data, f)
+            tmp_path = f.name
 
         cp_result = subprocess.run(
             [


### PR DESCRIPTION
## Summary

Fixes code-scanning alert 8 (py/insecure-temporary-file) in `r59_phase4_cleanup_stale_known_list.py`.

Replaced `tempfile.mktemp()` + manual `open()` with `tempfile.NamedTemporaryFile(delete=False)`, which creates the file atomically and avoids the race condition where an attacker could interfere with the file between name generation and opening.

The fix was originally pushed to the `perf/ha-sim-wait-optimization` branch after PR 117 was already merged, so it didn't make it into master. This PR cherry-picks the fix onto current master.

#### Test plan
- [x] `py_compile` passes
- [x] Pre-commit hooks pass (ruff, mypy)