### PR TITLE
fix(ha-sim): disable bluetooth in default config and include HGI in get_known_list

### DIFF
--- a/deployments/ha-sim/configuration.yaml.example
+++ b/deployments/ha-sim/configuration.yaml.example
@@ -19,9 +19,35 @@ homeassistant:
 http:
   server_port: 8124
 
-# Enable default integrations
-# This loads a sensible set of default integrations including frontend
-default_config:
+# Enable standard integrations (excluding bluetooth to avoid container permission warnings)
+api:
+automation:
+config:
+counter:
+dhcp:
+energy:
+frontend:
+history:
+homeassistant_hardware:
+input_boolean:
+input_button:
+input_datetime:
+input_number:
+input_select:
+input_text:
+logbook:
+media_source:
+my:
+person:
+scene:
+script:
+select:
+sun:
+system_health:
+tag:
+timer:
+webhook:
+zone:
 
 # Logging configuration
 logger:

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -392,6 +392,9 @@ def get_known_list() -> dict:
 
             dev_id_re = re.compile(r"^\d{2}:[0-9A-Fa-f]{6}$")
             known = {}
+            # Include gateway HGI ID (matching
+            # coordinator._derive_known_list_from_schema)
+            known.setdefault(get_current_instance().hgi_id, {})
             for k, v in schema.items():
                 if dev_id_re.match(str(k)):
                     known[str(k)] = v if isinstance(v, dict) else {}

--- a/tools/ha_sim_test/recipes/r58_phase4_known_list_removal_enforce_always_on.py
+++ b/tools/ha_sim_test/recipes/r58_phase4_known_list_removal_enforce_always_on.py
@@ -26,7 +26,7 @@ import json
 import subprocess
 
 from ..base import Recipe, RecipeContext
-from ..const import CTL, DHW, FAN, HGI, REM, TRV
+from ..const import CTL, DHW, FAN, REM, TRV
 from ..helpers import get_current_instance, get_known_list, get_schema_retry
 
 


### PR DESCRIPTION
### The Problem:
1. `deployments/ha-sim/configuration.yaml.example` used `default_config:`, which auto-loads Home Assistant's `bluetooth` integration. Because Docker containers without host network privileges lack `NET_ADMIN`/`NET_RAW` capabilities, HA logs permission errors trying to access Bluetooth hardware.
2. `get_known_list()` in `tools/ha_sim_test/helpers.py` manually parsed the schema from `.storage` but omitted the active gateway HGI ID (`get_current_instance().hgi_id`), causing a mismatch against `ramses_cc`'s coordinator derivation logic (`coordinator._derive_known_list_from_schema`).

### The Fix:
1. Replaced `default_config:` in `deployments/ha-sim/configuration.yaml.example` with an explicit list of default integrations excluding `bluetooth`.
2. Updated `get_known_list()` in `tools/ha_sim_test/helpers.py` to include the active gateway HGI ID.

### Testing Performed:
- Validated `ha_sim_test` test suite with updated configuration, passing `HGI in derived known_list` and eliminating Bluetooth log warnings.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.