### PR TITLE
fix(transport): start monitor loop even when ramses_cc client not ready (issue 116)

### DIFF
--- a/custom_components/ramses_extras/features/default/platforms/binary_sensor.py
+++ b/custom_components/ramses_extras/features/default/platforms/binary_sensor.py
@@ -86,7 +86,7 @@ async def _get_ramses_cc_coordinator(hass: HomeAssistant) -> Any | None:
 
 async def _start_transport_monitoring(hass: HomeAssistant) -> None:
     coordinator = await _get_ramses_cc_coordinator(hass)
-    if not coordinator or not getattr(coordinator, "client", None):
+    if not coordinator:
         _LOGGER.debug("ramses_cc coordinator not available for transport monitoring")
         return
 

--- a/custom_components/ramses_extras/framework/base_classes/base_automation.py
+++ b/custom_components/ramses_extras/framework/base_classes/base_automation.py
@@ -737,21 +737,36 @@ class ExtrasBaseAutomation(ABC):
     # ==================== TRANSPORT MONITORING ====================
 
     async def _start_transport_monitoring(self) -> None:
-        """Start transport monitoring if ramses_cc is available."""
+        """Start transport monitoring if ramses_cc is available.
+
+        Always starts the monitor loop when a coordinator is found, even if
+        the coordinator's client is not ready yet (common with MQTT
+        transports that connect asynchronously).  The monitor loop calls
+        _refresh_coordinator every 5 s, which will pick up the client once
+        it becomes available and register the message handler at that point.
+        """
         try:
             from ..helpers.ramses_commands import RamsesCommands
 
             commands = RamsesCommands(self.hass)
             coordinator = await commands._get_ramses_cc_coordinator()
 
-            if coordinator and coordinator.client:
+            if coordinator:
                 await self._transport_monitor.start_monitoring(coordinator, self.hass)
-                _LOGGER.info(
-                    "Transport monitoring started for %s automation", self.feature_id
-                )
+                if coordinator.client:
+                    _LOGGER.info(
+                        "Transport monitoring started for %s automation",
+                        self.feature_id,
+                    )
+                else:
+                    _LOGGER.info(
+                        "Transport monitoring loop started for %s automation, "
+                        "waiting for ramses_cc client to become available",
+                        self.feature_id,
+                    )
             else:
                 _LOGGER.debug(
-                    "ramses_cc not available yet, transport monitoring will start later"
+                    "ramses_cc coordinator not found, transport monitoring not started"
                 )
         except Exception as e:
             _LOGGER.debug(

--- a/custom_components/ramses_extras/framework/helpers/transport_monitor.py
+++ b/custom_components/ramses_extras/framework/helpers/transport_monitor.py
@@ -143,9 +143,17 @@ class TransportMonitor:
             self._msg_handler_unsub = None
 
         self._client = client
+
+        if client is None:
+            _LOGGER.debug(
+                "_ensure_msg_handler: no client available, "
+                "will retry via _refresh_coordinator"
+            )
+            return
+
         _LOGGER.debug("_ensure_msg_handler: client updated to %s", client)
 
-        add_msg_handler = getattr(client, "add_msg_handler", None) if client else None
+        add_msg_handler = getattr(client, "add_msg_handler", None)
         if callable(add_msg_handler):
             try:
                 self._msg_handler_unsub = add_msg_handler(self._handle_msg)
@@ -155,7 +163,11 @@ class TransportMonitor:
             except Exception as e:
                 _LOGGER.error("Failed to register message handler: %s", e)
         else:
-            _LOGGER.warning("Transport monitor: client has no add_msg_handler method")
+            _LOGGER.warning(
+                "Transport monitor: client %s has no add_msg_handler method "
+                "(ramses_rf may be too old)",
+                type(client).__name__,
+            )
 
     async def _device_timeout_handler(self, device_id: str) -> None:
         """Handle device timeout after 61s with no reply."""
@@ -269,8 +281,8 @@ class TransportMonitor:
 
             client = getattr(self._coordinator, "client", None)
             if client is None:
-                _LOGGER.warning(
-                    "Transport monitor: coordinator has no client, "
+                _LOGGER.info(
+                    "Transport monitor: coordinator has no client yet, "
                     "will retry via _refresh_coordinator"
                 )
             self._ensure_msg_handler(client)


### PR DESCRIPTION
## Summary

Fixes the `Transport monitor: client has no add_msg_handler method` warning and the subsequent "Device marked offline" errors reported in issue [#116](https://github.com/wimpie70/ramses_extras/issues/116#issuecomment-5084302910) by a user on ramses_esp over MQTT.

### Root cause

With MQTT transports (ramses_esp), the ramses_cc Gateway client is often not yet initialised when Home Assistant fires `homeassistant_started`. Both `_start_transport_monitoring` entry points (`base_automation.py` and `binary_sensor.py`) checked `if coordinator and coordinator.client:` and **gave up entirely** when the client was `None` — no monitor loop was started and no retry was attempted.

Without the monitor loop running:
- `_refresh_coordinator` never ran
- the message handler was never registered with ramses_cc
- device replies were never detected
- every commanded device was marked offline after 61s

The misleading warning `client has no add_msg_handler method` was logged even when the real issue was simply "no client found yet" (client was `None`), not "client exists but lacks the method".

### Changes

- **`base_automation.py` `_start_transport_monitoring`**: Always call `start_monitoring` when a coordinator is found, even if `coordinator.client` is `None`. The monitor loop's `_refresh_coordinator` (runs every 5s) picks up the client once it becomes available and registers the message handler at that point.
- **`binary_sensor.py` `_start_transport_monitoring`**: Same fix — drop the `coordinator.client` guard so the monitor loop starts for MQTT transports.
- **`transport_monitor.py` `_ensure_msg_handler`**: Distinguish "no client available" (debug log, will retry via `_refresh_coordinator`) from "client exists but lacks `add_msg_handler`" (warning with the client type name, suggesting ramses_rf may be too old).
- **`transport_monitor.py` `start_monitoring`**: Lowered the "coordinator has no client" log from warning to info, since it is an expected condition for MQTT that the monitor loop handles gracefully.

#### Test plan
- [x] `make local-ci` passes (4000 Python tests, ESLint, Jest 45 tests, ruff, mypy)
- [x] Existing transport_monitor tests pass (`test_transport_monitor*.py`)
- [x] Existing binary_sensor tests pass (`test_binary_sensor_functions.py`)
- [ ] Manual: verify with ramses_esp/MQTT transport that devices are no longer marked offline after 61s and the misleading warning no longer appears