### PR TITLE
feat(ha_sim_test): live per-container dashboard + global wait-scale knob

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,14 @@
-# AI Agent Instructions and Guidelines for ramses_extras
+# AI Agent Instructions for ramses_extras
 
-Project-specific rules for the `ramses_extras` codebase. Cross-repo rules
-(venvs, test invocation, typing, PR/commit conventions) live in the global
-rules file.
+The canonical coding standards, guardrails, and behavioural rules for
+AI/LLM contributors live in the repo itself. **You MUST read both of
+these files before working on ramses_extras:**
 
-## Architecture
-
-- **Feature-centric architecture**: The framework provides base classes,
-  helpers, and reusable code. The default feature is always enabled and is a
-  good place for common entities, servicecalls, etc.
-- **Architecture changes**: Before making architecture changes, first read
-  `docs/RAMSES_EXTRAS_ARCHITECTURE.md`.
+- **`LLM_INSTRUCTIONS.md`** (repo root) — behavioural rules, guardrails,
+  identity/tone, no-advertising, wait-for-approval, PR framing,
+  architecture, backward compatibility.
+- **`CONTRIBUTING.md`** (repo root) — coding standards, typing,
+  docstrings, testing, tooling.
 
 ## Test Environments (Home Assistant instances)
 
@@ -21,9 +19,3 @@ rules file.
   feature and runs against this instance.
 - **Production HA**: runs on a separate server. Do not point dev tools or
   tests at it.
-
-## Backward Compatibility
-
-- Backward compatibility is not required for now, **except** for the
-  `get`/`set`/`update` `fan_param` methods/functions/servicecalls, since this
-  is WIP on `ramses_cc`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,42 @@ If you have a card, automation or other that you would like included, please let
 regards, Willem
 
 ps. this is a work-in-progress. WIKI pages will come with info on how to contribute, requirements for PR's and examples.
+
+---
+
+## Coding & Development Standards
+
+All contributions (whether written by human contributors or generated via AI coding assistants) must strictly adhere to the following standards:
+
+### 1. Code Style & Conventions
+
+- **Line Constraints**: PEP 8 compliance (code <= 79 characters, docstrings/comments <= 72 characters).
+- **EXEMPTION (Raw Data)**: Raw RF packets, hex strings, routing dictionaries, and timestamped packet logs are strictly exempt from line limits to preserve readability and grep-ability.
+- **String Literals**: Prefer double quotes (`"`) for all string literals.
+- **Deferred Logging**: Always use standard deferred `%`-formatting across all log levels and logger instances (e.g., `_LOGGER.debug(...)`) instead of `f-strings` to prevent string evaluation and interpolation overhead when logging is disabled or filtered.
+
+### 2. Typing & Type Safety
+
+- **Strict Type Safety**: 100% compliance with `mypy`. Do not introduce untyped definitions (`Any`) without strong technical justification.
+- **Domain Types**: Prefer domain-specific types (`Address`, `DeviceIdT`, dataclasses, enums) over primitive `str` or `dict`.
+- **Python Syntax**: Use modern Python 3.13+ syntax:
+  - Use `|` for unions (e.g., `str | int`).
+  - Use native collection types (e.g., `list[int]`, `dict[str, Any]`).
+  - **Banned Imports**: Do not import `List`, `Dict`, `Set`, `Tuple`, `Optional`, or `Union` from `typing`.
+
+### 3. Code Quality & Modularity
+
+- **Immutability & State**: Treat data objects as immutable where possible. Avoid unnecessary state mutations and return new instances instead.
+- **Context Managers**: Avoid nested `with` statements. Use parenthetical multi-context syntax (`with (A(), B()):`).
+- **Imports**: Place imports at module level (top of file). Combine imports from the same module onto a single line (`combine-as-imports = true`).
+
+### 4. Documentation & Comments
+
+- **Public APIs**: Require full Sphinx-style docstrings (summary, detailed explanation, `:param:`, `:type:`, `:returns:`, `:rtype:`).
+- **Private Helpers**: Concise, single-line summaries are preferred for internal helpers (`_helper`).
+- **Preserve Inline Comments**: Treat existing comments, `#TODO`, `#FIXME`, and `#HACK` markers as locked anchors. Multi-line wrap comments rather than truncating text.
+
+### 5. Testing & Verification
+
+- **Test Structure**: Exempt from Sphinx docstrings. Use descriptive test names following the **Arrange, Act, Assert (AAA)** pattern with inline comments.
+- **Tooling**: Verify changes locally using `~/venvs/extras/bin/prek run -a`, `~/venv/extras/bin/ruff check .`, `~/venvs/extras/bin/mypy`, and `~/venvs/extras/bin/pytest`.

--- a/LLM_INSTRUCTIONS.md
+++ b/LLM_INSTRUCTIONS.md
@@ -1,0 +1,30 @@
+# AI Agent Instructions and Guidelines for ramses_extras
+
+This file contains behavioral rules and guardrails for any AI agent or LLM working on the `ramses_extras` codebase.
+
+For all general coding, typing, docstring, and architectural standards, you **must strictly adhere** to [CONTRIBUTING.md](https://github.com/wimpie70/ramses_extras/blob/main/CONTRIBUTING.md).
+
+## 1. Identity, Tone & Behavior
+
+- **Professional Tone**: Keep feedback, PR titles, and PR descriptions professional, objective, and concise. Avoid marketing-style hype or aggressive terminology (e.g. avoid words like "lobotomy", "purge", "nuke", "eradicate").
+- **No Advertising**: Never add signatures like "co-authored by Devin" or promote AI tools in commits, comments, code, or PR descriptions.
+- **Wait for Approval**: Do not automatically commit or push code unless explicitly instructed by the user.
+- **Must Pass Tests**: Ensure all linter checks (`prek`, `ruff`, `mypy`) and test suites (`pytest`) pass cleanly before declaring success.
+- **PR Description Framing**: Keep PR titles and descriptions lean, factual, and scaled to the complexity of the change. Avoid AI-generated lengthy risk analyses or hypothetical scenarios.
+
+## 2. Code Modification Guardrails
+
+- **Surgical Precision**: Modify only lines strictly necessary to complete the task. Do not perform unrequested "general cleanup" on legacy code.
+- **Comment Preservation**: Treat existing inline comments, `#TODO`, `#FIXME`, and `#HACK` markers as sacred anchors. Git relies on line stability; preserving comments preserves history.
+- **Wrap, Don't Hack**: When wrapping long comments or docstrings, never truncate sentences or strip English determiners/words to force line limits. Use standard multi-line wrapping.
+- **Tooling Execution**: Use project virtual environment binaries (e.g., `~/venvs/extras/bin/pytest`, `~/venvs/extras/bin/prek run -a`). Do not invent custom runner scripts or bypass existing quality checks.
+- **Cross-Repository References**: Fully qualify cross-repository issue and PR references (e.g., `ramses-rf/ramses_cc#123`).
+
+## 3. Architecture (project-specific)
+
+- **Feature-centric architecture**: The framework provides base classes, helpers, and reusable code. The default feature is always enabled and is a good place for common entities, servicecalls, etc.
+- **Architecture changes**: Before making architecture changes, first read `docs/RAMSES_EXTRAS_ARCHITECTURE.md`.
+
+## 4. Backward Compatibility (project-specific)
+
+- Backward compatibility is not required for now, **except** for the `get`/`set`/update` `fan_param`methods/functions/servicecalls, since this is WIP on`ramses_cc`.

--- a/custom_components/ramses_extras/features/device_simulator/__init__.py
+++ b/custom_components/ramses_extras/features/device_simulator/__init__.py
@@ -627,7 +627,7 @@ async def create_device_simulator_feature(
 
     _LOGGER.info("Creating new MqttEndpoint...")
     registry["device_simulator_endpoint"] = MqttEndpoint(
-        hass, topic_base=SIMULATOR_TOPIC_NS
+        hass, gateway_id=SIMULATOR_HGI_ID, topic_base=SIMULATOR_TOPIC_NS
     )
     _LOGGER.info(
         "Created MqttEndpoint instance: %s", id(registry["device_simulator_endpoint"])

--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -69,12 +69,138 @@ To run specific recipes only:
 python3 -m ha_sim_test R06 R29
 ```
 
-The test suite takes ~6 minutes to complete. Output is printed to stdout with:
+The test suite takes ~6 minutes to complete (single container). Output is printed to stdout with:
 - A section header for each recipe
 - `PASS:` / `FAIL:` lines for each check
 - A summary at the end with the total count
 
 Exit code: `0` = all passed, `1` = some failed.
+
+### CLI parameters
+
+```
+usage: ha_sim_test [-h] [--parallel N] [--container-base CONTAINER_BASE]
+                   [--port PORT] [--assign CONTAINER:R1,R2,...] [--cleanup]
+                   [--wait-scale-blind FACTOR] [--wait-scale-poll FACTOR]
+                   [recipes ...]
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `recipes` (positional) | all | Recipe IDs to run (e.g. `R06 R29`). Order is preserved. |
+| `--parallel N` | `1` | Run across N containers in parallel. `1` = sequential on `ha-sim`. See [Parallel mode](#parallel-mode). |
+| `--container-base` | `ha-sim` | Base container name. Instance 1 uses this name directly; instances 2+ get a suffix (e.g. `ha-sim-2`). |
+| `--port PORT` | `8124` | Starting HA port for instance 1. Instances 2+ use `port+1`, `port+2`, etc. |
+| `--assign CONTAINER:R1,R2,...` | (auto) | Manual recipe assignment (advanced). Can be repeated. Unassigned recipes are auto-distributed. Example: `--assign ha-sim-2:R01,R02`. |
+| `--cleanup` | off | Stop and remove parallel containers (instances 2+) and their cloned config dirs after the run. Without this flag, containers are stopped but config dirs are kept for warm restarts. Instance 1 (`ha-sim`) is always left running. |
+| `--wait-scale-blind FACTOR` | `1.0` | Scale factor for fixed `wait()` blind sleeps. See [Wait scaling](#wait-scaling). |
+| `--wait-scale-poll FACTOR` | `1.0` | Scale factor for `wait_for()` timeout ceilings. See [Wait scaling](#wait-scaling). |
+
+### Examples
+
+```bash
+# Run all recipes on the default ha-sim container
+python3 -m ha_sim_test
+
+# Run two specific recipes
+python3 -m ha_sim_test R06 R29
+
+# Run across 4 containers in parallel, clean up afterwards
+python3 -m ha_sim_test --parallel 4 --cleanup
+
+# Run on 2 containers, manually assigning recipes to containers
+python3 -m ha_sim_test --parallel 2 \
+    --assign ha-sim:R01,R02,R03 \
+    --assign ha-sim-2:R04,R05,R06
+
+# Run fast: tighten poll ceilings only (safe, big win on failures)
+python3 -m ha_sim_test --wait-scale-poll 0.1
+
+# Run aggressive: halve blind sleeps AND tighten poll ceilings
+python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
+
+# Run on 4 containers with aggressive wait scaling
+python3 -m ha_sim_test --parallel 4 --cleanup \
+    --wait-scale-blind 0.5 --wait-scale-poll 0.1
+
+# Pipe to a log file (dashboard auto-disables, plain interleaved output)
+python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1
+```
+
+### Parallel mode
+
+When `--parallel N` is greater than 1, the runner spins up N HA containers
+(`ha-sim`, `ha-sim-2`, ..., `ha-sim-N`) and distributes the recipes across
+them. Each container gets its own config dir (cloned from `ha-sim`'s
+`.storage`) and its own HA port.
+
+- **Container naming:** `--container-base ha-sim` → `ha-sim`,
+  `ha-sim-2`, `ha-sim-3`, ...
+- **Port assignment:** `--port 8124` → 8124, 8125, 8126, ...
+- **Recipe distribution:** recipes are split evenly across containers
+  in seq order. Use `--assign` for manual control.
+- **Warm restarts:** without `--cleanup`, stopped containers keep their
+  config dirs so the next run starts faster (no fresh schema learning).
+  Use `--cleanup` to remove them for a cold start.
+- **Instance 1 (`ha-sim`)** is always left running after the run (it's
+  the dev/debug instance); only instances 2+ are stopped.
+
+### Live dashboard
+
+In parallel mode, when stdout is a real terminal, a live per-container
+dashboard is rendered instead of a wall of interleaved raw prints. Each
+container gets a fixed-height pane showing:
+
+- Current recipe being executed
+- Running pass/fail tally
+- Elapsed time
+- Last few output lines
+
+The panes refresh in place via ANSI cursor movement. Output is
+attributed to the correct container via the existing contextvars-based
+`get_current_instance()` mechanism — not by parsing `[name]` text
+prefixes — so attribution is correct even when containers execute
+concurrently (interleaved at `await` points).
+
+The dashboard auto-disables when stdout isn't a TTY (e.g. piped to a
+file or running in CI), so existing `> file.log 2>&1` + `grep`
+workflows are completely unaffected.
+
+### Wait scaling
+
+The suite has ~138 fixed blind sleeps (`wait(N)`, totalling ~730s) and
+~63 polling waits (`wait_for(timeout=N)`, self-exiting). Two independent
+scale knobs let you trade safety for speed:
+
+- **`--wait-scale-blind FACTOR`** (or `HA_SIM_TEST_WAIT_SCALE_BLIND`):
+  scales every fixed `wait()`/`ctx.wait()` blind sleep. These are the
+  dominant cost — 80 of 138 calls use `wait(5)`, totalling ~400s — and
+  also the riskiest to cut: 5s is already a deliberate "let MQTT/HA
+  settle" pause, so 5→0.5 is a 10x cut on something that may genuinely
+  need 2-3s.
+
+- **`--wait-scale-poll FACTOR`** (or `HA_SIM_TEST_WAIT_SCALE_POLL`):
+  scales every `wait_for()` timeout ceiling. These poll and return as
+  soon as the condition is met, so the timeout is just a safety margin.
+  On the simulator, conditions typically resolve in 2-3s; if they
+  haven't, the test has probably failed. Scaling 30s→3s just tightens
+  the failure ceiling — safe to cut aggressively.
+
+**Precedence:** CLI flag > per-bucket env var > legacy
+`HA_SIM_TEST_WAIT_SCALE` (sets both) > default `1.0`.
+
+| Goal | Blind | Poll | Notes |
+|---|---|---|---|
+| Safe speedup on failures | 1.0 | 0.1 | Only tightens poll ceilings; blind sleeps unchanged |
+| Moderate speedup | 0.5 | 0.1 | Halves blind sleeps too; good for local iteration |
+| Find the minimum | 0.25 | 0.05 | Will likely break something — that's the point |
+| Slow machine / debugging | 2.0 | 2.0 | Give everything more headroom |
+
+**Finding bottlenecks:** the global knobs are good for "can I run the
+suite 2x faster?" and "which recipe breaks first when I push it?" (the
+dashboard shows which container failed). They do *not* tell you which
+specific `wait(15)` should be a `wait(5)` — for that you'd want per-wait
+timing telemetry (not yet implemented).
 
 ## Test report
 

--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -124,7 +124,8 @@ python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
 # RECOMMENDED fast run: scale + floor protects sensitive waits
 # (0 new failures vs baseline, ~9.8 min wall time on 4 containers)
 python3 -m ha_sim_test --parallel 4 --cleanup \
-    --wait-scale-blind 0.5 --wait-scale-poll 0.1 --wait-floor-blind 3
+    --wait-scale-blind 0.5 --wait-scale-poll 0.1 \
+    --wait-floor-blind 3 --wait-floor-poll 5
 
 # Pipe to a log file (dashboard auto-disables, plain interleaved output)
 python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1
@@ -205,12 +206,12 @@ scale knobs let you trade safety for speed:
 `HA_SIM_TEST_WAIT_SCALE` (sets both) > default `1.0`. Floors default to
 0 (no protection); per-call `floor=` takes the max with the global floor.
 
-| Goal | Blind | Poll | Floor blind | Notes |
-|---|---|---|---|---|
-| Safe speedup on failures | 1.0 | 0.1 | 0 | Only tightens poll ceilings |
-| **Recommended fast run** | **0.5** | **0.1** | **3** | **0 new failures, ~9.8 min on 4 containers** |
-| Aggressive | 0.25 | 0.05 | 3 | May still break post-restart hydration |
-| Slow machine / debugging | 2.0 | 2.0 | 0 | Give everything more headroom |
+| Goal | Blind | Poll | Floor blind | Floor poll | Notes |
+|---|---|---|---|---|---|
+| Safe speedup on failures | 1.0 | 0.1 | 0 | 0 | Only tightens poll ceilings |
+| **Recommended fast run** | **0.5** | **0.1** | **3** | **5** | **0 new failures, ~10 min on 4 containers** |
+| Aggressive | 0.25 | 0.05 | 3 | 5 | May still break post-restart hydration |
+| Slow machine / debugging | 2.0 | 2.0 | 0 | 0 | Give everything more headroom |
 
 **Output format:** when a wait is scaled, the output shows both the
 original and actual duration: `Waiting 5s→3s for sync_learned_topology...`

--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -115,16 +115,11 @@ python3 -m ha_sim_test --parallel 2 \
     --assign ha-sim:R01,R02,R03 \
     --assign ha-sim-2:R04,R05,R06
 
-# Run fast: tighten poll ceilings only (safe, big win on failures)
-python3 -m ha_sim_test --wait-scale-poll 0.1
+# Run fast: defaults are already 0.5/0.08/3 — no flags needed
+python3 -m ha_sim_test --parallel 4 --cleanup
 
-# Run aggressive: halve blind sleeps AND tighten poll ceilings
-python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
-
-# RECOMMENDED fast run: scale + floor protects sensitive waits
-# (0 new failures vs baseline, ~9 min wall time on 4 containers)
-python3 -m ha_sim_test --parallel 4 --cleanup \
-    --wait-scale-blind 0.5 --wait-scale-poll 0.08 --wait-floor-blind 3
+# Run safe (no scaling, full waits)
+python3 -m ha_sim_test --wait-scale-blind 1.0 --wait-scale-poll 1.0 --wait-floor-blind 0
 
 # Pipe to a log file (dashboard auto-disables, plain interleaved output)
 python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1

--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -95,6 +95,8 @@ usage: ha_sim_test [-h] [--parallel N] [--container-base CONTAINER_BASE]
 | `--cleanup` | off | Stop and remove parallel containers (instances 2+) and their cloned config dirs after the run. Without this flag, containers are stopped but config dirs are kept for warm restarts. Instance 1 (`ha-sim`) is always left running. |
 | `--wait-scale-blind FACTOR` | `1.0` | Scale factor for fixed `wait()` blind sleeps. See [Wait scaling](#wait-scaling). |
 | `--wait-scale-poll FACTOR` | `1.0` | Scale factor for `wait_for()` timeout ceilings. See [Wait scaling](#wait-scaling). |
+| `--wait-floor-blind SECONDS` | `0` | Global minimum (real-time seconds) for all blind `wait()` sleeps. Protects sensitive waits when using aggressive scale factors. |
+| `--wait-floor-poll SECONDS` | `0` | Global minimum for all `wait_for()` timeout ceilings. Per-call `floor=` (e.g. `wait_for_ha_ready` uses 10s) takes the max with this. |
 
 ### Examples
 
@@ -119,9 +121,10 @@ python3 -m ha_sim_test --wait-scale-poll 0.1
 # Run aggressive: halve blind sleeps AND tighten poll ceilings
 python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
 
-# Run on 4 containers with aggressive wait scaling
+# RECOMMENDED fast run: scale + floor protects sensitive waits
+# (0 new failures vs baseline, ~9.8 min wall time on 4 containers)
 python3 -m ha_sim_test --parallel 4 --cleanup \
-    --wait-scale-blind 0.5 --wait-scale-poll 0.1
+    --wait-scale-blind 0.5 --wait-scale-poll 0.1 --wait-floor-blind 3
 
 # Pipe to a log file (dashboard auto-disables, plain interleaved output)
 python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1
@@ -186,21 +189,38 @@ scale knobs let you trade safety for speed:
   haven't, the test has probably failed. Scaling 30s→3s just tightens
   the failure ceiling — safe to cut aggressively.
 
+- **`--wait-floor-blind SECONDS`** (or `HA_SIM_TEST_WAIT_FLOOR_BLIND`):
+  global minimum (real-time seconds) that all blind sleeps respect,
+  regardless of the scale factor. When using aggressive scale factors,
+  this protects sensitive waits (scan engine processing, sync operations,
+  entity hydration) that need a hard minimum of ~3s. The output shows
+  both the original and scaled values: `Waiting 5s→3s for sync...`.
+
+- **`--wait-floor-poll SECONDS`** (or `HA_SIM_TEST_WAIT_FLOOR_POLL`):
+  same for `wait_for()` timeout ceilings. The per-call `floor=` parameter
+  (e.g. `wait_for_ha_ready` uses floor=10 for docker restarts) takes the
+  max with this global floor.
+
 **Precedence:** CLI flag > per-bucket env var > legacy
-`HA_SIM_TEST_WAIT_SCALE` (sets both) > default `1.0`.
+`HA_SIM_TEST_WAIT_SCALE` (sets both) > default `1.0`. Floors default to
+0 (no protection); per-call `floor=` takes the max with the global floor.
 
-| Goal | Blind | Poll | Notes |
-|---|---|---|---|
-| Safe speedup on failures | 1.0 | 0.1 | Only tightens poll ceilings; blind sleeps unchanged |
-| Moderate speedup | 0.5 | 0.1 | Halves blind sleeps too; good for local iteration |
-| Find the minimum | 0.25 | 0.05 | Will likely break something — that's the point |
-| Slow machine / debugging | 2.0 | 2.0 | Give everything more headroom |
+| Goal | Blind | Poll | Floor blind | Notes |
+|---|---|---|---|---|
+| Safe speedup on failures | 1.0 | 0.1 | 0 | Only tightens poll ceilings |
+| **Recommended fast run** | **0.5** | **0.1** | **3** | **0 new failures, ~9.8 min on 4 containers** |
+| Aggressive | 0.25 | 0.05 | 3 | May still break post-restart hydration |
+| Slow machine / debugging | 2.0 | 2.0 | 0 | Give everything more headroom |
 
-**Finding bottlenecks:** the global knobs are good for "can I run the
-suite 2x faster?" and "which recipe breaks first when I push it?" (the
-dashboard shows which container failed). They do *not* tell you which
-specific `wait(15)` should be a `wait(5)` — for that you'd want per-wait
-timing telemetry (not yet implemented).
+**Output format:** when a wait is scaled, the output shows both the
+original and actual duration: `Waiting 5s→3s for sync_learned_topology...`
+or `Waiting up to 30s→10s for ha-sim to start up...`. This makes it
+visible which waits are being shortened and by how much.
+
+**Docker restart floors:** `wait_for_ha_ready()` has a built-in floor of
+10s — docker restarts take a hard 3-5s minimum before the API is
+reachable, so scaling below 10s makes no sense. This is separate from
+the global `--wait-floor-poll` (the effective floor is the max of both).
 
 ## Test report
 

--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -122,10 +122,9 @@ python3 -m ha_sim_test --wait-scale-poll 0.1
 python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
 
 # RECOMMENDED fast run: scale + floor protects sensitive waits
-# (0 new failures vs baseline, ~9.8 min wall time on 4 containers)
+# (0 new failures vs baseline, ~10 min wall time on 4 containers)
 python3 -m ha_sim_test --parallel 4 --cleanup \
-    --wait-scale-blind 0.5 --wait-scale-poll 0.1 \
-    --wait-floor-blind 3 --wait-floor-poll 5
+    --wait-scale-blind 0.5 --wait-scale-poll 0.1 --wait-floor-blind 3
 
 # Pipe to a log file (dashboard auto-disables, plain interleaved output)
 python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1
@@ -206,12 +205,18 @@ scale knobs let you trade safety for speed:
 `HA_SIM_TEST_WAIT_SCALE` (sets both) > default `1.0`. Floors default to
 0 (no protection); per-call `floor=` takes the max with the global floor.
 
-| Goal | Blind | Poll | Floor blind | Floor poll | Notes |
-|---|---|---|---|---|---|
-| Safe speedup on failures | 1.0 | 0.1 | 0 | 0 | Only tightens poll ceilings |
-| **Recommended fast run** | **0.5** | **0.1** | **3** | **5** | **0 new failures, ~10 min on 4 containers** |
-| Aggressive | 0.25 | 0.05 | 3 | 5 | May still break post-restart hydration |
-| Slow machine / debugging | 2.0 | 2.0 | 0 | 0 | Give everything more headroom |
+| Goal | Blind | Poll | Floor blind | Notes |
+|---|---|---|---|---|
+| Safe speedup on failures | 1.0 | 0.1 | 0 | Only tightens poll ceilings |
+| **Recommended fast run** | **0.5** | **0.1** | **3** | **0 new failures, ~10 min on 4 containers** |
+| Aggressive | 0.25 | 0.05 | 3 | May still break post-restart hydration |
+| Slow machine / debugging | 2.0 | 2.0 | 0 | Give everything more headroom |
+
+Per-call floors (built into helpers, no CLI flag needed):
+``wait_for_ha_ready``: floor=10s (docker restart)
+``wait_for_ramses_cc_loaded``: floor=15s (docker restart cold start)
+``wait_for_ramses_cc_reload``: floor=5s (in-process profile reload)
+``wait_for_schema_stable``: floor=3s (polls schema, exits early when stable)
 
 **Output format:** when a wait is scaled, the output shows both the
 original and actual duration: `Waiting 5s→3s for sync_learned_topology...`

--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -122,9 +122,9 @@ python3 -m ha_sim_test --wait-scale-poll 0.1
 python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
 
 # RECOMMENDED fast run: scale + floor protects sensitive waits
-# (0 new failures vs baseline, ~10 min wall time on 4 containers)
+# (0 new failures vs baseline, ~9 min wall time on 4 containers)
 python3 -m ha_sim_test --parallel 4 --cleanup \
-    --wait-scale-blind 0.5 --wait-scale-poll 0.1 --wait-floor-blind 3
+    --wait-scale-blind 0.5 --wait-scale-poll 0.08 --wait-floor-blind 3
 
 # Pipe to a log file (dashboard auto-disables, plain interleaved output)
 python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1
@@ -208,15 +208,24 @@ scale knobs let you trade safety for speed:
 | Goal | Blind | Poll | Floor blind | Notes |
 |---|---|---|---|---|
 | Safe speedup on failures | 1.0 | 0.1 | 0 | Only tightens poll ceilings |
-| **Recommended fast run** | **0.5** | **0.1** | **3** | **0 new failures, ~10 min on 4 containers** |
-| Aggressive | 0.25 | 0.05 | 3 | May still break post-restart hydration |
+| **Recommended fast run** | **0.5** | **0.08** | **3** | **0 new failures, ~9 min on 4 containers** |
+| Aggressive | 0.5 | 0.05 | 3 | 2-3 new flaky fails (R11/R24/R36 race conditions) |
 | Slow machine / debugging | 2.0 | 2.0 | 0 | Give everything more headroom |
+
+Going below 0.08 poll scale introduces flaky failures from timing-sensitive
+operations (scan engine processing, entity state writes, class_mismatch
+detection) that can't be fixed with floors alone — they're inherent race
+conditions in the HA entity state machine.
 
 Per-call floors (built into helpers, no CLI flag needed):
 ``wait_for_ha_ready``: floor=10s (docker restart)
 ``wait_for_ramses_cc_loaded``: floor=15s (docker restart cold start)
-``wait_for_ramses_cc_reload``: floor=5s (in-process profile reload)
+``wait_for_ramses_cc_reload``: floor=8s (in-process profile reload)
 ``wait_for_schema_stable``: floor=3s (polls schema, exits early when stable)
+``wait_for_schema_populated``: floor=3s (polls schema key count)
+``wait_for_schema_has``: floor=3s (polls for specific device in schema)
+``wait_for_entity_state``: floor=3s (polls entity state via REST)
+``wait_for_transport_reconnect``: floor=3s (polls MQTT subscription log)
 
 **Output format:** when a wait is scaled, the output shows both the
 original and actual duration: `Waiting 5s→3s for sync_learned_topology...`

--- a/docs/notepad.txt
+++ b/docs/notepad.txt
@@ -352,3 +352,77 @@ age the cached 1060 timestamps in `.storage/ramses_cc` before restarting.
 - tools/ha_sim_test.py — append Recipe 32 after Recipe 31 (line ~3645)
 - ramses_rf: src/ramses_rf/const.py — remove `Code._1060,` from
   HIGH_VOLUME_STATUS_CODES (the actual fix; separate PR, references 840)
+
+## ha_sim_test 4-container parallel suite — remaining failures (Aug 1 2026)
+Baseline after landing the ramses_rf HVC-default-class fix (PR
+https://github.com/ramses-rf/ramses_rf/pull/968 — "not a valid value
+@ data['bound']" during fresh_start reloads): 380 passed / 8 failed
+(down from 17 failed before the fix). ha-sim-2 (previously the most
+flaky — R22/R20 fresh_start reload timeouts) now 100% passes. Remaining
+8 are unrelated pre-existing bugs, to investigate one at a time:
+
+1. `[ha-sim]` R47ish: "unknown device 04:999999 in get_discovered_devices
+   (log output)" — device not found in get_discovered_devices log
+   output. Possibly a timing/log-scrape flake rather than a real bug.
+2. `[ha-sim-3]` "Invalid main_tcs cleared after sanitisation" —
+   main_tcs=04:999999 not cleared as expected.
+3. `[ha-sim-3]` "Invalid main_tcs persisted to config entry" — config
+   entry still references 04:999999 (companion to #2, same root cause
+   likely — sanitisation not persisting/re-running after config entry
+   write).
+4. `[ha-sim-3]` "No ramses_cc ERROR logs during stress test" — ERROR
+   logs found during R16 concurrency/stress test (rapid add/remove +
+   inject). Need to capture which ERROR specifically.
+5. `[ha-sim-3]` R36 (issue 843): "climate state is 'heat' (not
+   unknown/None)" — state='unknown'/None; target_temperature not
+   hydrated from 2349 (21.0°C). Known/tracked issue 843, pre-existing.
+6. `[ha-sim-4]` "Zone 03 has _name set (0004 RP to foreign HGI not
+   blocked)" — _name=None, meaning the 0004 RP was blocked by
+   block_list when the test expected it to pass through (or vice
+   versa — re-check R37/R34-adjacent foreign-HGI block_list recipe
+   intent).
+7. `[ha-sim-4]` R32 (issue 840): "TRV battery binary sensor retained
+   state after restart (stale 1060)" — state=None after aging cached
+   packets 2h and restarting. This is the documented Recipe 32 PREP
+   above (section "PREP: Recipe 32 — Battery (1060) cache restore
+   regression") — fix is `ramses_rf/src/ramses_rf/const.py`: remove
+   `Code._1060,` from `HIGH_VOLUME_STATUS_CODES` (separate PR).
+8. (duplicate-ish of #1) R47 `get_discovered_devices` log-output
+   flakiness — confirm whether #1 and this are the same failure
+   reported by two different assertions in the same recipe.
+
+Suggested order: #7 (already scoped, known fix) → #5 (issue 843,
+likely same discovery/hydration family as #7) → #2/#3 (same recipe,
+investigate together) → #6 → #4/#1/#8 (flakier, investigate last).
+
+## ha_sim_test speed & live feedback improvements (Aug 1 2026)
+- Added `HA_SIM_TEST_WAIT_SCALE` env var (default `1.0`) in
+  `tools/ha_sim_test/helpers.py` — scales every fixed `wait()`/
+  `ctx.wait()` sleep and every `wait_for()` timeout/interval ceiling.
+  `ctx.wait()` in `base.py` now delegates to `helpers.wait()` so it
+  gets scaling for free. Try `HA_SIM_TEST_WAIT_SCALE=0.5 python -m
+  ha_sim_test ...` to see which recipes tolerate faster runs, then
+  consider lowering literal `ctx.wait(N, ...)` values in the recipes
+  that turn out to be over-conservative (138 fixed `ctx.wait()` calls
+  across recipes currently sum to ~730s of pure sleep time — the
+  dominant cost in a full single-container run).
+- Added `tools/ha_sim_test/dashboard.py` (`LiveDashboard`): live,
+  in-place-updating per-container status panes (7 lines each: header
+  with current recipe + pass/fail tally + elapsed time, plus 6 lines
+  of recent output) during `--parallel N` runs. Attributes stdout
+  lines to the correct container via the existing
+  `get_current_instance()` contextvar (not by parsing `[name]`
+  prefixes), so it works correctly even though asyncio interleaves
+  containers at arbitrary points. Auto-disables (falls back to the
+  original plain interleaved prints) when stdout isn't a real TTY —
+  e.g. piped to a log file — so `> file.log` capture for `grep`-based
+  analysis is unaffected. Wired into `run_parallel()` in `parallel.py`.
+- Confirmed (by grepping interleaved `>>> Running` markers across all
+  4 containers in a full run) that containers genuinely run
+  concurrently, not sequentially — despite no explicit
+  `asyncio.to_thread`/threading in the codebase. This works because
+  some helpers (e.g. `ws_send` over aiohttp) have real `await` points
+  that yield control between blocking sections; worth keeping in mind
+  since long stretches of pure `ctx.wait()`/`time.sleep()` inside one
+  recipe will still stall other containers' progress until the next
+  yield point.

--- a/tests/features/default/test_websocket_working.py
+++ b/tests/features/default/test_websocket_working.py
@@ -21,6 +21,12 @@ class TestWebSocketBasic:
                 "devices": [],
             }
         }
+
+        def _swallow_coro(coro, *args, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        hass.async_create_background_task = MagicMock(side_effect=_swallow_coro)
         return hass
 
     @pytest.fixture

--- a/tests/features/device_simulator/test_init.py
+++ b/tests/features/device_simulator/test_init.py
@@ -223,7 +223,13 @@ class TestLoadFeature:
         hass = MagicMock()
         config_entry = MagicMock()
 
-        with patch("asyncio.create_task") as mock_create_task:
+        def _swallow_coro(coro, *args, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        with patch(
+            "asyncio.create_task", side_effect=_swallow_coro
+        ) as mock_create_task:
             result = load_feature(hass, config_entry)
 
             assert result["feature_name"] == "device_simulator"

--- a/tests/features/device_simulator/test_profile_loader.py
+++ b/tests/features/device_simulator/test_profile_loader.py
@@ -19,6 +19,12 @@ from custom_components.ramses_extras.features.device_simulator.profile_loader im
 )
 
 
+def _swallow_coro(coro, *args, **kwargs):
+    """Side-effect that closes a coroutine to avoid 'never awaited' warnings."""
+    coro.close()
+    return MagicMock()
+
+
 class TestEnsureHgiEntry:
     """Test _ensure_hgi_entry function."""
 
@@ -350,7 +356,7 @@ class TestUpdateKnownListAndReload:
         hass.config_entries.async_entries = MagicMock(return_value=[entry])
         hass.config_entries.async_update_entry = MagicMock()
         hass.config_entries.async_setup = AsyncMock()
-        hass.async_create_task = MagicMock()
+        hass.async_create_task = MagicMock(side_effect=_swallow_coro)
 
         with patch("homeassistant.helpers.storage.Store") as mock_store_class:
             mock_store = MagicMock()

--- a/tests/features/device_simulator/test_scenarios.py
+++ b/tests/features/device_simulator/test_scenarios.py
@@ -60,6 +60,21 @@ from custom_components.ramses_extras.features.device_simulator.scenarios.timeout
 )
 
 
+def _make_create_task_side_effect() -> callable:
+    """Return a side_effect that schedules coroutines instead of swallowing them.
+
+    Using ``async def`` as a ``side_effect`` on a ``MagicMock`` causes the
+    coroutine to never be awaited (MagicMock calls it but doesn't await the
+    returned coroutine).  This helper returns a regular function that
+    schedules the coroutine as a task on the running event loop.
+    """
+
+    def _create_task(coro, name=None, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        return asyncio.ensure_future(coro)
+
+    return _create_task
+
+
 class TestScenarioResult:
     """Test ScenarioResult dataclass."""
 
@@ -254,15 +269,18 @@ class TestScenarioContext:
         async def mock_coro():
             pass
 
+        coro = mock_coro()
         hass.async_create_background_task = MagicMock(return_value=MagicMock())
         engine = MagicMock()
 
         context = ScenarioContext(hass, engine)
 
-        result = context.schedule_background_task(mock_coro(), name="test")
+        result = context.schedule_background_task(coro, name="test")
 
         hass.async_create_background_task.assert_called_once()
         assert result is not None
+        # Close the coroutine to avoid "never awaited" RuntimeWarning
+        coro.close()
 
     @pytest.mark.asyncio
     async def test_cancel_existing(self):
@@ -875,12 +893,9 @@ class TestDeviceUnavailability:
         engine._active_devices = {"37:168270": MagicMock()}
         engine.async_cancel_scenario = AsyncMock()
 
-        async def mock_create_task(coro, name):
-            # Actually await the coroutine to avoid warnings
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
         context = ScenarioContext(hass, engine)
 
         params = {"device_id": "37:168270"}
@@ -898,11 +913,9 @@ class TestDeviceUnavailability:
         engine._active_devices = {"37:168270": MagicMock()}
         engine.async_cancel_scenario = AsyncMock()
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
         context = ScenarioContext(hass, engine)
 
         params = {"targets": ["37:168270"]}
@@ -920,11 +933,9 @@ class TestDeviceUnavailability:
         engine._active_devices = {"37:168270": MagicMock()}
         engine.async_cancel_scenario = AsyncMock()
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
         context = ScenarioContext(hass, engine)
 
         params = {"targets": "37:168270"}
@@ -999,11 +1010,9 @@ class TestDiscoveryTest:
         engine = MagicMock()
         engine.async_cancel_scenario = AsyncMock()
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
         context = ScenarioContext(hass, engine)
 
         params = {"device_id": "37:168270"}
@@ -1027,11 +1036,9 @@ class TestDiscoveryTest:
         context = ScenarioContext(hass, engine)
         context.device_db.find_response = MagicMock(return_value=None)
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         result = await discovery_test_run(context, {"slug": "fan"})
 
@@ -1061,11 +1068,9 @@ class TestDiscoveryTest:
 
         context.device_db.find_response = MagicMock(side_effect=_find_response)
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         result = await discovery_test_run(context, {"slug": "FAN"})
 
@@ -1080,11 +1085,9 @@ class TestDiscoveryTest:
         engine.async_cancel_scenario = AsyncMock()
         context = ScenarioContext(hass, engine)
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         # Mock fingerprint lookup
         context.device_db.get_fingerprint_payload = MagicMock(return_value="ABCDEF")
@@ -1249,11 +1252,9 @@ class TestFloodingTest:
         entry.payloads = ["000000"]
         context.device_db.get_periodic = MagicMock(return_value=[entry])
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         params = {"device_id": "37:168270", "code": "22F7", "count": 10}
 
@@ -1363,11 +1364,9 @@ class TestHvacDeviceLoss:
         engine.async_cancel_scenario = AsyncMock()
         context = ScenarioContext(hass, engine)
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         params = {"device_id": "37:168270"}
 
@@ -1453,11 +1452,9 @@ class TestTimeoutTest:
         engine.async_cancel_scenario = AsyncMock()
         context = ScenarioContext(hass, engine)
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         params = {"device_id": "37:168270"}
 
@@ -1476,11 +1473,9 @@ class TestTimeoutTest:
         engine.async_cancel_scenario = AsyncMock()
         context = ScenarioContext(hass, engine)
 
-        async def mock_create_task(coro, name):
-            await coro
-            return MagicMock()
-
-        hass.async_create_background_task = MagicMock(side_effect=mock_create_task)
+        hass.async_create_background_task = MagicMock(
+            side_effect=_make_create_task_side_effect()
+        )
 
         params = {"device_id": "37:168270", "drop_codes": ["1FC9", "31DA"]}
 

--- a/tests/features/device_simulator/test_websocket.py
+++ b/tests/features/device_simulator/test_websocket.py
@@ -1,5 +1,6 @@
 """Tests for device simulator WebSocket commands."""
 
+import asyncio
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -53,13 +54,20 @@ from custom_components.ramses_extras.features.device_simulator.websocket_command
 # which don't expose __wrapped__, so we test them as-is
 
 
+def _swallow_coro(coro, *args, **kwargs):
+    """Side-effect that closes a coroutine to avoid 'never awaited' warnings."""
+    coro.close()
+    return MagicMock()
+
+
 @pytest.fixture
 def hass():
     hass = MagicMock()
     hass.data = {}
     hass.config.config_dir = "/tmp/test"
     hass.bus.async_fire = MagicMock()
-    hass.async_create_background_task = MagicMock()
+    hass.async_create_background_task = MagicMock(side_effect=_swallow_coro)
+    hass.async_create_task = MagicMock(side_effect=_swallow_coro)
     return hass
 
 
@@ -605,9 +613,13 @@ class TestWsSetDeviceExcludedCodes:
             "device_id": "37:168270",
             "excluded_codes": ["1FC9"],
         }
-        ws_set_device_excluded_codes(hass, connection, msg)
+        with patch(
+            "custom_components.ramses_extras.features.device_simulator."
+            "websocket_commands.asyncio.create_task",
+            side_effect=_swallow_coro,
+        ):
+            ws_set_device_excluded_codes(hass, connection, msg)
         connection.send_result.assert_called_once()
-        # _fire_device_change_event is called via asyncio.create_task, not awaited
 
     def test_ws_set_device_excluded_codes_not_ready(self, hass, connection):
         hass.data = {}
@@ -883,10 +895,17 @@ class TestWsLoadProfile:
         config_store.get_profile = MagicMock(return_value=profile)
         config_store.set_active_profile = MagicMock()
         config_store.async_save_state = AsyncMock()
-        with patch(
-            "custom_components.ramses_extras.features.device_simulator.websocket_commands.async_apply_profile",
-            new=AsyncMock(return_value={}),
-        ) as mock_apply:
+        with (
+            patch(
+                "custom_components.ramses_extras.features.device_simulator.websocket_commands.async_apply_profile",
+                new=AsyncMock(return_value={}),
+            ) as mock_apply,
+            patch(
+                "custom_components.ramses_extras.features.device_simulator."
+                "websocket_commands.asyncio.create_task",
+                side_effect=_swallow_coro,
+            ),
+        ):
             hass.data = {
                 "ramses_extras": {
                     "device_simulator_engine": engine,
@@ -1255,11 +1274,17 @@ class TestWsSetDeviceEnabled:
         engine._fire_device_change_event = AsyncMock()
         engine.auto_answer_enabled = True
         hass.data = {"ramses_extras": {"device_simulator_engine": engine}}
-        await _unwrap(ws_set_device_enabled)(
-            hass,
-            connection,
-            {"id": 1, "type": "x", "device_id": "37:168270", "enabled": True},
-        )
+        # Patch asyncio.create_task to close fire-and-forget coroutines
+        with patch(
+            "custom_components.ramses_extras.features.device_simulator."
+            "websocket_commands.asyncio.create_task",
+            side_effect=_swallow_coro,
+        ):
+            await _unwrap(ws_set_device_enabled)(
+                hass,
+                connection,
+                {"id": 1, "type": "x", "device_id": "37:168270", "enabled": True},
+            )
         assert device.enabled is True
         engine.async_activate_device.assert_awaited_once()
         # _fire_device_change_event is called via asyncio.create_task, not awaited
@@ -2528,7 +2553,7 @@ class TestOtherHandlerErrorPaths:
         engine.set_answer_unknown_devices = MagicMock()
         config_store.set_answer_unknown_devices = MagicMock()
         config_store.async_save_state = AsyncMock()
-        hass.async_create_background_task = MagicMock()
+        hass.async_create_background_task = MagicMock(side_effect=_swallow_coro)
         msg = {"id": 1, "type": "test", "enabled": False}
         hass.data = {
             "ramses_extras": {

--- a/tests/features/ramses_debugger/test_ramses_debugger_init.py
+++ b/tests/features/ramses_debugger/test_ramses_debugger_init.py
@@ -25,6 +25,13 @@ class TestCreateRamsesDebuggerFeature:
         mock_hass.data = {}
         mock_hass.bus = MagicMock()
         mock_hass.bus.async_listen = MagicMock()
+
+        def _swallow_coro(coro, *args, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        mock_hass.async_create_task = MagicMock(side_effect=_swallow_coro)
+        mock_hass.async_create_background_task = MagicMock(side_effect=_swallow_coro)
         return mock_hass
 
     @pytest.fixture

--- a/tests/features/sensor_control/test_config_flow_direct.py
+++ b/tests/features/sensor_control/test_config_flow_direct.py
@@ -356,7 +356,7 @@ class TestPersistFunctions:
         flow = MagicMock()
         flow.config_entry = MagicMock()
         flow.hass = MagicMock()
-        flow.hass.config_entries.async_update_entry = AsyncMock()
+        flow.hass.config_entries.async_update_entry = MagicMock()
         options = {}
         section = {"area_sensors": [{"area_id": "area1"}]}
 
@@ -369,7 +369,7 @@ class TestPersistFunctions:
         flow = MagicMock()
         flow.config_entry = MagicMock()
         flow.hass = MagicMock()
-        flow.hass.config_entries.async_update_entry = AsyncMock()
+        flow.hass.config_entries.async_update_entry = MagicMock()
         flow._refresh_config_entry = MagicMock()
         options = {}
         section = {"rem_devices": [{"rem_id": "32:153290"}]}
@@ -383,7 +383,7 @@ class TestPersistFunctions:
         flow = MagicMock()
         flow.config_entry = MagicMock()
         flow.hass = MagicMock()
-        flow.hass.config_entries.async_update_entry = AsyncMock()
+        flow.hass.config_entries.async_update_entry = MagicMock()
         flow._sensor_control_selected_device = "32:153289"
         options = {}
         section = {"zones": [{"zone_id": "zone1"}]}

--- a/tests/features/sensor_control/test_websocket_commands.py
+++ b/tests/features/sensor_control/test_websocket_commands.py
@@ -30,8 +30,8 @@ def hass():
 def connection():
     """Mock websocket connection."""
     conn = MagicMock()
-    conn.send_result = AsyncMock()
-    conn.send_error = AsyncMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
     return conn
 
 

--- a/tests/features/test_full_coverage.py
+++ b/tests/features/test_full_coverage.py
@@ -10,6 +10,12 @@ import custom_components.ramses_extras.features.default.websocket_commands as we
 import custom_components.ramses_extras.features.sensor_control.config_flow as config_flow  # noqa: E501
 
 
+def _swallow_coro(coro, *args, **kwargs):
+    """Side-effect that closes a coroutine to avoid 'never awaited' warnings."""
+    coro.close()
+    return MagicMock()
+
+
 class TestServicesFullCoverage:
     """Full coverage tests for services."""
 
@@ -54,6 +60,7 @@ class TestWebSocketFullCoverage:
         """Test websocket commands to get coverage."""
         hass = MagicMock()
         hass.data = {}
+        hass.async_create_background_task = MagicMock(side_effect=_swallow_coro)
         connection = MagicMock()
         connection.send_message = MagicMock()
         connection.send_error = MagicMock()

--- a/tests/framework/helpers/test_ramses_commands.py
+++ b/tests/framework/helpers/test_ramses_commands.py
@@ -16,7 +16,15 @@ from custom_components.ramses_extras.framework.helpers.ramses_commands import (
 @pytest.fixture
 def hass():
     """Mock Home Assistant."""
-    return MagicMock()
+    hass = MagicMock()
+
+    def _swallow_coro(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    hass.async_create_task = MagicMock(side_effect=_swallow_coro)
+    hass.async_create_background_task = MagicMock(side_effect=_swallow_coro)
+    return hass
 
 
 @pytest.fixture

--- a/tests/framework/helpers/test_transport_monitor_coverage.py
+++ b/tests/framework/helpers/test_transport_monitor_coverage.py
@@ -12,6 +12,12 @@ from custom_components.ramses_extras.framework.helpers.transport_monitor import 
 )
 
 
+def _swallow_coro(coro, *args, **kwargs):
+    """Side-effect that closes a coroutine to avoid 'never awaited' warnings."""
+    coro.close()
+    return MagicMock()
+
+
 @pytest.fixture
 def monitor():
     """Create a fresh TransportMonitor instance."""
@@ -59,7 +65,7 @@ class TestTransportMonitorCoverage:
     def test_notify_command_sent_starts_timer(self, monitor):
         """Test notify_command_sent starts a timeout timer."""
         hass = MagicMock()
-        hass.async_create_task = MagicMock(return_value=MagicMock())
+        hass.async_create_task = MagicMock(side_effect=_swallow_coro)
         monitor._hass = hass
 
         monitor.notify_command_sent("32_123456")
@@ -84,6 +90,9 @@ class TestTransportMonitorCoverage:
         """Test update_device_message_received cancels timeout timer."""
         hass = MagicMock()
         hass.loop = MagicMock()
+        hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda func, coro, *a, **kw: coro.close()
+        )
         hass.data = {"ramses_cc": {"mock_coordinator": MagicMock(client=MagicMock())}}
         existing_task = MagicMock()
         existing_task.done.return_value = False
@@ -99,6 +108,11 @@ class TestTransportMonitorCoverage:
         """Test update_device_message_received when no timer exists."""
         hass = MagicMock()
         hass.loop = MagicMock()
+        # call_soon_threadsafe receives async_create_task and a coroutine;
+        # close the coroutine to avoid "never awaited" warnings
+        hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda func, coro, *a, **kw: coro.close()
+        )
         monitor._hass = hass
 
         # Should not crash
@@ -353,7 +367,9 @@ class TestTransportMonitorCoverage:
         """Test mark_device_offline_immediate."""
         hass = MagicMock()
         monitor._hass = hass
-        hass.loop.call_soon_threadsafe = MagicMock()
+        hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda func, coro, *a, **kw: coro.close()
+        )
 
         monitor.mark_device_offline_immediate("32_123456")
 
@@ -376,7 +392,9 @@ class TestTransportMonitorCoverage:
         """Test mark_device_offline_immediate cancels existing task."""
         hass = MagicMock()
         monitor._hass = hass
-        hass.loop.call_soon_threadsafe = MagicMock()
+        hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda func, coro, *a, **kw: coro.close()
+        )
 
         existing_task = MagicMock()
         existing_task.done.return_value = False
@@ -568,6 +586,9 @@ class TestTransportMonitorCoverage:
 
         # Should not crash
         assert monitor._coordinator is coordinator
+
+        # Clean up the monitor task to avoid "never awaited" warnings
+        await monitor.stop_monitoring()
 
     @pytest.mark.asyncio
     async def test_stop_monitoring_cleanup_event_unsub(self, monitor):

--- a/tests/framework/helpers/test_zone_coordinator.py
+++ b/tests/framework/helpers/test_zone_coordinator.py
@@ -23,7 +23,12 @@ def hass():
     """Mock Home Assistant instance."""
     hass_mock = MagicMock()
     hass_mock.data = {}
-    hass_mock.async_create_task = MagicMock()
+
+    def _swallow_coro(coro, *args, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    hass_mock.async_create_task = MagicMock(side_effect=_swallow_coro)
     return hass_mock
 
 

--- a/tests/framework/helpers/test_zone_demand.py
+++ b/tests/framework/helpers/test_zone_demand.py
@@ -435,7 +435,12 @@ class TestGetZoneDemandRegistry:
         # Mock the event loop
         loop = MagicMock()
         call_later = MagicMock()
-        async_create_task = MagicMock()
+
+        def _swallow_coro(coro, *args, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        async_create_task = MagicMock(side_effect=_swallow_coro)
         bus = MagicMock()
         fire_event = MagicMock()
 

--- a/tests/framework/test_devices_setup.py
+++ b/tests/framework/test_devices_setup.py
@@ -58,7 +58,10 @@ async def test_async_setup_platforms_retries_when_not_loaded(hass) -> None:
         scheduled.append(delay)
         # avoid recursion: mark setup not in progress then invoke callback
         devices._setup_in_progress = False
-        return callback(None)
+        coro = callback(None)
+        # Close the coroutine to avoid "never awaited" warnings
+        coro.close()
+        return MagicMock()
 
     with patch(
         "custom_components.ramses_extras.framework.setup.devices.async_call_later",

--- a/tests/framework/test_yaml_setup.py
+++ b/tests/framework/test_yaml_setup.py
@@ -94,7 +94,10 @@ async def test_async_setup_yaml_config_logs_exception(hass, caplog) -> None:
     failing_flow = AsyncMock()
     hass.config_entries.flow.async_init = failing_flow
 
-    def _raise_on_create_task(_: Any) -> None:  # type: ignore[override]
+    def _raise_on_create_task(coro: Any) -> None:  # type: ignore[override]
+        # Close the coroutine to avoid "never awaited" warnings
+        if hasattr(coro, "close"):
+            coro.close()
         raise RuntimeError("boom")
 
     hass.async_create_task = _raise_on_create_task  # type: ignore[assignment]

--- a/tests/test_main_init.py
+++ b/tests/test_main_init.py
@@ -747,9 +747,18 @@ class TestAsyncSetupPlatforms:
             async_setup_platforms,
         )
 
+        def _swallow_coro(*args, **kwargs):
+            # async_call_later(hass, delay, callback) — close the coroutine
+            # callback to avoid "never awaited" warnings
+            callback = args[2] if len(args) > 2 else kwargs.get("action")
+            if callback is not None and hasattr(callback, "close"):
+                callback.close()
+            return MagicMock()
+
         hass.config.components = set()  # No ramses_cc
         with patch(
-            "custom_components.ramses_extras.framework.setup.devices.async_call_later"
+            "custom_components.ramses_extras.framework.setup.devices.async_call_later",
+            side_effect=_swallow_coro,
         ) as mock_call_later:
             await async_setup_platforms(hass)
             mock_call_later.assert_called_once()

--- a/tools/ha_sim_test/__main__.py
+++ b/tools/ha_sim_test/__main__.py
@@ -8,6 +8,7 @@ Usage::
     python3 -m ha_sim_test --parallel 4 --cleanup
     python3 -m ha_sim_test --wait-scale-poll 0.1          # tighten poll ceilings
     python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
+    python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-floor-blind 3  # safe fast
 """
 
 from __future__ import annotations
@@ -82,17 +83,39 @@ def main() -> None:
         "only tightens the failure ceiling. Safe to cut aggressively on the "
         "simulator (e.g. 0.1 -> 30s ceiling becomes 3s).",
     )
+    parser.add_argument(
+        "--wait-floor-blind",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Global minimum (seconds, real time) for all blind wait() sleeps. "
+        "Protects sensitive waits (scan engine, sync, entity hydration) when "
+        "using aggressive --wait-scale-blind. E.g. --wait-scale-blind 0.5 "
+        "--wait-floor-blind 3 means wait(5)->3s, wait(10)->5s, wait(2)->3s.",
+    )
+    parser.add_argument(
+        "--wait-floor-poll",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Global minimum (seconds) for all wait_for() timeout ceilings. "
+        "The per-call floor= parameter (e.g. wait_for_ha_ready uses floor=10) "
+        "takes the max with this.",
+    )
     args = parser.parse_args()
 
-    # Apply CLI wait-scale overrides (env vars are read at import time in
-    # helpers.py; CLI flags take precedence and update the module vars).
-    if args.wait_scale_blind is not None or args.wait_scale_poll is not None:
-        from . import helpers
+    # Apply CLI wait-scale/floor overrides (env vars are read at import time
+    # in helpers.py; CLI flags take precedence and update the module vars).
+    from . import helpers
 
-        if args.wait_scale_blind is not None:
-            helpers.WAIT_SCALE_BLIND = args.wait_scale_blind
-        if args.wait_scale_poll is not None:
-            helpers.WAIT_SCALE_POLL = args.wait_scale_poll
+    if args.wait_scale_blind is not None:
+        helpers.WAIT_SCALE_BLIND = args.wait_scale_blind
+    if args.wait_scale_poll is not None:
+        helpers.WAIT_SCALE_POLL = args.wait_scale_poll
+    if args.wait_floor_blind is not None:
+        helpers.WAIT_FLOOR_BLIND = args.wait_floor_blind
+    if args.wait_floor_poll is not None:
+        helpers.WAIT_FLOOR_POLL = args.wait_floor_poll
 
     recipe_ids = args.recipes or None
 

--- a/tools/ha_sim_test/__main__.py
+++ b/tools/ha_sim_test/__main__.py
@@ -6,6 +6,8 @@ Usage::
     python3 -m ha_sim_test R06 R29      # run specific recipes by id
     python3 -m ha_sim_test --parallel 2 # run across 2 containers
     python3 -m ha_sim_test --parallel 4 --cleanup
+    python3 -m ha_sim_test --wait-scale-poll 0.1          # tighten poll ceilings
+    python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
 """
 
 from __future__ import annotations
@@ -61,7 +63,36 @@ def main() -> None:
         "are stopped but config dirs are kept for warm restarts. "
         "Instance 1 (ha-sim) is always left running.",
     )
+    parser.add_argument(
+        "--wait-scale-blind",
+        type=float,
+        default=None,
+        metavar="FACTOR",
+        help="Scale factor for fixed wait() blind sleeps (default: 1.0, or "
+        "HA_SIM_TEST_WAIT_SCALE_BLIND if set). E.g. 0.5 halves all 5s/10s/..."
+        " sleeps. The dominant cost is 80 calls to wait(5) totalling ~400s.",
+    )
+    parser.add_argument(
+        "--wait-scale-poll",
+        type=float,
+        default=None,
+        metavar="FACTOR",
+        help="Scale factor for wait_for() timeout ceilings (default: 1.0, or "
+        "HA_SIM_TEST_WAIT_SCALE_POLL if set). Polling returns early, so this "
+        "only tightens the failure ceiling. Safe to cut aggressively on the "
+        "simulator (e.g. 0.1 -> 30s ceiling becomes 3s).",
+    )
     args = parser.parse_args()
+
+    # Apply CLI wait-scale overrides (env vars are read at import time in
+    # helpers.py; CLI flags take precedence and update the module vars).
+    if args.wait_scale_blind is not None or args.wait_scale_poll is not None:
+        from . import helpers
+
+        if args.wait_scale_blind is not None:
+            helpers.WAIT_SCALE_BLIND = args.wait_scale_blind
+        if args.wait_scale_poll is not None:
+            helpers.WAIT_SCALE_POLL = args.wait_scale_poll
 
     recipe_ids = args.recipes or None
 

--- a/tools/ha_sim_test/__main__.py
+++ b/tools/ha_sim_test/__main__.py
@@ -2,13 +2,10 @@
 
 Usage::
 
-    python3 -m ha_sim_test              # run all recipes in seq order
+    python3 -m ha_sim_test              # run all recipes (defaults: 0.5/0.08/3)
     python3 -m ha_sim_test R06 R29      # run specific recipes by id
-    python3 -m ha_sim_test --parallel 2 # run across 2 containers
-    python3 -m ha_sim_test --parallel 4 --cleanup
-    python3 -m ha_sim_test --wait-scale-poll 0.1          # tighten poll ceilings
-    python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-scale-poll 0.1
-    python3 -m ha_sim_test --wait-scale-blind 0.5 --wait-floor-blind 3  # safe fast
+    python3 -m ha_sim_test --parallel 4 --cleanup  # fast: ~9 min, 0 new fails
+    python3 -m ha_sim_test --wait-scale-blind 1.0 --wait-scale-poll 1.0  # safe
 """
 
 from __future__ import annotations
@@ -69,7 +66,7 @@ def main() -> None:
         type=float,
         default=None,
         metavar="FACTOR",
-        help="Scale factor for fixed wait() blind sleeps (default: 1.0, or "
+        help="Scale factor for fixed wait() blind sleeps (default: 0.5, or "
         "HA_SIM_TEST_WAIT_SCALE_BLIND if set). E.g. 0.5 halves all 5s/10s/..."
         " sleeps. The dominant cost is 80 calls to wait(5) totalling ~400s.",
     )
@@ -78,20 +75,21 @@ def main() -> None:
         type=float,
         default=None,
         metavar="FACTOR",
-        help="Scale factor for wait_for() timeout ceilings (default: 1.0, or "
+        help="Scale factor for wait_for() timeout ceilings (default: 0.08, or "
         "HA_SIM_TEST_WAIT_SCALE_POLL if set). Polling returns early, so this "
         "only tightens the failure ceiling. Safe to cut aggressively on the "
-        "simulator (e.g. 0.1 -> 30s ceiling becomes 3s).",
+        "simulator (e.g. 0.08 -> 30s ceiling becomes 2.4s).",
     )
     parser.add_argument(
         "--wait-floor-blind",
         type=float,
         default=None,
         metavar="SECONDS",
-        help="Global minimum (seconds, real time) for all blind wait() sleeps. "
-        "Protects sensitive waits (scan engine, sync, entity hydration) when "
-        "using aggressive --wait-scale-blind. E.g. --wait-scale-blind 0.5 "
-        "--wait-floor-blind 3 means wait(5)->3s, wait(10)->5s, wait(2)->3s.",
+        help="Global minimum (seconds, real time) for all blind wait() sleeps "
+        "(default: 3). Protects sensitive waits (scan engine, sync, entity "
+        "hydration) when using aggressive --wait-scale-blind. E.g. "
+        "--wait-scale-blind 0.5 --wait-floor-blind 3 means wait(5)->3s, "
+        "wait(10)->5s, wait(2)->3s.",
     )
     parser.add_argument(
         "--wait-floor-poll",

--- a/tools/ha_sim_test/base.py
+++ b/tools/ha_sim_test/base.py
@@ -102,9 +102,9 @@ class RecipeContext:
             self.results.append(f"  FAIL: {label} {detail}")
             print(f"  FAIL: {label} {detail}")
 
-    def wait(self, seconds: int, msg: str = "") -> None:
+    def wait(self, seconds: int, msg: str = "", *, floor: float = 0.0) -> None:
         """Wait and print progress (delegates to helpers.wait)."""
-        _wait(seconds, msg)
+        _wait(seconds, msg, floor=floor)
 
     def wait_for(
         self,
@@ -112,6 +112,8 @@ class RecipeContext:
         timeout: int = 30,
         interval: float = 1.0,
         msg: str = "",
+        *,
+        floor: float = 0.0,
     ) -> bool:
         """Poll a condition until it returns True or timeout is reached.
 
@@ -119,6 +121,10 @@ class RecipeContext:
         Checks ``condition`` every ``interval`` seconds.  Returns True
         if the condition was met within ``timeout`` seconds, False
         otherwise.  Prints progress like :meth:`wait`.
+
+        *floor* sets a minimum absolute timeout (seconds, pre-scaling)
+        that the scaled timeout won't go below — use it for waits with
+        a hard physical minimum (e.g. docker restarts).
 
         Example::
 
@@ -129,7 +135,20 @@ class RecipeContext:
             ):
                 ...
         """
-        return _wait_for(condition, timeout, interval, msg)
+        return _wait_for(condition, timeout, interval, msg, floor=floor)
+
+    def wait_for_ha_ready(
+        self,
+        timeout: int = 30,
+        msg: str = "for ha-sim to start up",
+    ) -> bool:
+        """Wait for HA to be ready after a docker restart (floored at 10s).
+
+        See :func:`helpers.wait_for_ha_ready` for details.
+        """
+        from .helpers import wait_for_ha_ready as _wait_for_ha_ready
+
+        return _wait_for_ha_ready(timeout=timeout, msg=msg)
 
     def log_section(self, title: str) -> None:
         """Emit a labelled section banner in the test output."""

--- a/tools/ha_sim_test/base.py
+++ b/tools/ha_sim_test/base.py
@@ -150,6 +150,37 @@ class RecipeContext:
 
         return _wait_for_ha_ready(timeout=timeout, msg=msg)
 
+    def wait_for_ramses_cc_loaded(
+        self,
+        timeout: int = 30,
+        msg: str = "for ramses_cc to initialize",
+    ) -> bool:
+        """Wait for ramses_cc to load after a docker restart (floored at 15s).
+
+        See :func:`helpers.wait_for_ramses_cc_loaded` for details.
+        """
+        from .helpers import wait_for_ramses_cc_loaded as _w
+
+        return _w(timeout=timeout, msg=msg)
+
+    def wait_for_schema_stable(
+        self,
+        timeout: int = 10,
+        quiet: float = 1.0,
+        msg: str = "for schema to stabilise",
+    ) -> bool:
+        """Wait until the schema stops changing (polls, exits early).
+
+        Replaces blind ``wait(5, "for sync_learned_topology")`` and
+        ``wait(5, "for save_client_state")`` — typically returns in 1-2s
+        once the schema has been quiet for *quiet* seconds.
+
+        See :func:`helpers.wait_for_schema_stable` for details.
+        """
+        from .helpers import wait_for_schema_stable as _w
+
+        return _w(timeout=timeout, quiet=quiet, msg=msg)
+
     def log_section(self, title: str) -> None:
         """Emit a labelled section banner in the test output."""
         _log_section(title)

--- a/tools/ha_sim_test/base.py
+++ b/tools/ha_sim_test/base.py
@@ -36,7 +36,6 @@ Two registration styles are supported (see :mod:`.registry`):
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -44,6 +43,7 @@ from typing import Any
 from .const import InstanceConfig
 from .helpers import get_token, set_current_instance
 from .helpers import log_section as _log_section
+from .helpers import wait as _wait
 from .helpers import wait_for as _wait_for
 
 
@@ -103,10 +103,8 @@ class RecipeContext:
             print(f"  FAIL: {label} {detail}")
 
     def wait(self, seconds: int, msg: str = "") -> None:
-        """Wait and print progress (mirrors helpers.wait)."""
-        print(f"  Waiting {seconds}s {msg}...", end="", flush=True)
-        time.sleep(seconds)
-        print(" done")
+        """Wait and print progress (delegates to helpers.wait)."""
+        _wait(seconds, msg)
 
     def wait_for(
         self,

--- a/tools/ha_sim_test/base.py
+++ b/tools/ha_sim_test/base.py
@@ -163,6 +163,19 @@ class RecipeContext:
 
         return _w(timeout=timeout, msg=msg)
 
+    def wait_for_ramses_cc_reload(
+        self,
+        timeout: int = 20,
+        msg: str = "for ramses_cc reload",
+    ) -> bool:
+        """Wait for ramses_cc reload after profile change (floored at 5s).
+
+        See :func:`helpers.wait_for_ramses_cc_reload` for details.
+        """
+        from .helpers import wait_for_ramses_cc_reload as _w
+
+        return _w(timeout=timeout, msg=msg)
+
     def wait_for_schema_stable(
         self,
         timeout: int = 10,

--- a/tools/ha_sim_test/dashboard.py
+++ b/tools/ha_sim_test/dashboard.py
@@ -1,0 +1,203 @@
+"""Live per-container status dashboard for parallel ha_sim_test runs.
+
+Renders a fixed-height pane per container (current recipe, running
+pass/fail tally, elapsed time, last few output lines) that refreshes in
+place using ANSI cursor movement, instead of a wall of interleaved raw
+prints from all containers.
+
+Attribution works by intercepting ``sys.stdout.write()`` and looking up
+the *currently active* :class:`~.const.InstanceConfig` via the same
+``contextvars``-based mechanism the parallel runner already uses
+(:func:`.helpers.get_current_instance`) — not by parsing ``[name]``
+prefixes out of the text.  Since ``asyncio`` runs one task's code at a
+time, whichever task is executing when a line is printed is the
+correct owner, regardless of whether that line happens to also contain
+its own ``[name]`` tag (which is stripped for display since it would be
+redundant with the pane's own header).
+
+Falls back to a complete no-op (no interception, no reserved screen
+space) when stdout is not a TTY — e.g. piped to a file for later
+``grep``, or running in CI — so existing log-capture workflows are
+unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TextIO
+
+from .helpers import get_current_instance
+
+_RUNNING_RE = re.compile(r">>> Running (\S+) \(seq=\d+\): (.*)")
+_TAG_RE = re.compile(r"^\s*\[[\w-]+\]\s*")
+
+
+def _terminal_width(default: int = 100) -> int:
+    try:
+        return shutil.get_terminal_size((default, 24)).columns
+    except Exception:
+        return default
+
+
+@dataclass
+class _Pane:
+    """Mutable render state for a single container's status pane."""
+
+    name: str
+    recipe: str = "-"
+    title: str = ""
+    passed: int = 0
+    failed: int = 0
+    start: float = field(default_factory=time.monotonic)
+    lines: deque[str] = field(default_factory=lambda: deque(maxlen=6))
+    done: bool = False
+
+    def feed(self, text: str) -> None:
+        """Absorb a chunk of stdout text attributed to this pane."""
+        for raw in text.splitlines():
+            line = raw.rstrip()
+            if not line:
+                continue
+            m = _RUNNING_RE.search(line)
+            if m:
+                self.recipe, self.title = m.group(1), m.group(2)
+            stripped = _TAG_RE.sub("", line).strip()
+            if not stripped:
+                continue
+            if stripped.startswith("PASS:"):
+                self.passed += 1
+            elif stripped.startswith("FAIL:"):
+                self.failed += 1
+            self.lines.append(stripped)
+
+
+class LiveDashboard:
+    """Fixed per-container status panes that refresh in place.
+
+    Usage::
+
+        dash = LiveDashboard([inst.name for inst in instances])
+        dash.start()
+        try:
+            results = await asyncio.gather(*tasks)
+        finally:
+            await dash.stop()
+
+    Each pane is ``LINES_PER_PANE`` terminal lines tall: one header line
+    (container name, current recipe, pass/fail tally, elapsed time) and
+    up to ``LINES_PER_PANE - 1`` of the most recent output lines.
+    """
+
+    LINES_PER_PANE = 7
+
+    def __init__(self, names: list[str], *, interval: float = 0.5) -> None:
+        self._panes: dict[str, _Pane] = {n: _Pane(name=n) for n in names}
+        self._interval = interval
+        self._real_stdout: TextIO = sys.stdout
+        self._task: asyncio.Task[None] | None = None
+        self._lines_drawn = 0
+        # Only take over the terminal when there's an actual terminal to
+        # take over — piping to a file/CI keeps the plain interleaved
+        # print() behaviour so `grep`-based log analysis still works.
+        self._enabled = sys.stdout.isatty()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    # -- stdout interception ------------------------------------------------
+    def write(self, text: str) -> int:
+        if not text:
+            return 0
+        try:
+            name = get_current_instance().name
+        except Exception:
+            name = None
+        pane = self._panes.get(name) if name else None
+        if pane is None:
+            # Not attributable to a container pane (e.g. printed before any
+            # per-container task set the contextvar) — pass through as-is.
+            return self._real_stdout.write(text)
+        pane.feed(text)
+        return len(text)
+
+    def flush(self) -> None:
+        self._real_stdout.flush()
+
+    def isatty(self) -> bool:
+        return self._real_stdout.isatty()
+
+    # -- rendering ------------------------------------------------------
+    def _render(self) -> None:
+        cols = _terminal_width()
+        out: list[str] = []
+        if self._lines_drawn:
+            out.append(f"\x1b[{self._lines_drawn}A")
+        n_lines = 0
+        for pane in self._panes.values():
+            elapsed = time.monotonic() - pane.start
+            status = "done " if pane.done else "..."
+            header = (
+                f"  {pane.name:<10} [{pane.recipe:<5}] {pane.title[:38]:<38} "
+                f"P:{pane.passed:>3} F:{pane.failed:>3} {elapsed:>5.0f}s {status}"
+            )
+            out.append(_fit(header, cols))
+            n_lines += 1
+            tail = list(pane.lines)
+            for line in tail:
+                out.append(_fit(f"    {line}", cols))
+                n_lines += 1
+            for _ in range(max(self.LINES_PER_PANE - 1 - len(tail), 0)):
+                out.append("\x1b[K")
+                n_lines += 1
+        self._lines_drawn = n_lines
+        self._real_stdout.write("\n".join(out) + "\n")
+        self._real_stdout.flush()
+
+    async def _refresh_loop(self) -> None:
+        try:
+            while True:
+                self._render()
+                await asyncio.sleep(self._interval)
+        except asyncio.CancelledError:
+            pass
+
+    def mark_done(self, name: str) -> None:
+        pane = self._panes.get(name)
+        if pane:
+            pane.done = True
+
+    # -- lifecycle ------------------------------------------------------
+    def start(self) -> None:
+        if not self._enabled:
+            return
+        # Reserve blank screen space matching what _render() will draw.
+        n = len(self._panes) * self.LINES_PER_PANE
+        self._real_stdout.write("\n" * n)
+        self._lines_drawn = n
+        sys.stdout = self
+        self._task = asyncio.get_event_loop().create_task(self._refresh_loop())
+
+    async def stop(self) -> None:
+        if not self._enabled:
+            return
+        sys.stdout = self._real_stdout
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._render()
+
+
+def _fit(s: str, width: int) -> str:
+    if len(s) > width:
+        s = s[: max(width - 1, 0)]
+    return s + "\x1b[K"

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -686,20 +686,25 @@ def find_entity_for_device(
 def wait(seconds: int, msg: str = "", *, floor: float = 0.0) -> None:
     """Wait and print progress (scaled by ``WAIT_SCALE_BLIND``).
 
-    *floor* sets a minimum absolute sleep (seconds, pre-scaling) that the
+    *floor* sets a minimum absolute sleep (seconds, real time) that the
     scaled sleep will not go below — use it for sensitive waits that need
     a hard minimum regardless of the global scale factor::
 
         wait(5, "for scan engine", floor=3)
-        # At WAIT_SCALE_BLIND=0.5: scaled = max(5*0.5, 3) = 3s, not 2.5s
+        # At WAIT_SCALE_BLIND=0.5: scaled = min(max(2.5, 3), 5) = 3s, not 2.5s
+
+    The floor never makes a wait *longer* than its original value — it
+    only protects against scaling too aggressively.  So ``wait(2)`` with
+    floor=3 stays 2s (the floor can't extend it beyond the original).
 
     The global ``WAIT_FLOOR_BLIND`` also applies — the effective floor is
     ``max(floor, WAIT_FLOOR_BLIND)``.
     """
     effective_floor = max(floor, WAIT_FLOOR_BLIND)
-    scaled = max(seconds * WAIT_SCALE_BLIND, effective_floor)
+    scaled = min(max(seconds * WAIT_SCALE_BLIND, effective_floor), seconds)
     if scaled != seconds:
-        print(f"  Waiting {seconds}s→{scaled:.0f}s {msg}...", end="", flush=True)
+        scaled_str = f"{scaled:g}"
+        print(f"  Waiting {seconds}s→{scaled_str}s {msg}...", end="", flush=True)
     else:
         print(f"  Waiting {seconds}s {msg}...", end="", flush=True)
     time.sleep(scaled)
@@ -723,23 +728,27 @@ def wait_for(
     *condition* is met, so scaling down mainly tightens the safety
     margin for genuinely slow conditions.
 
-    *floor* sets a minimum absolute timeout (in seconds, before scaling)
-    that the scaled timeout will not go below.  Use it for waits that
-    have a hard physical minimum (e.g. docker container restart takes
-    ~3-5s regardless of how aggressively you scale)::
+    *floor* sets a minimum absolute timeout (in seconds, real time) that
+    the scaled timeout will not go below.  Use it for waits that have a
+    hard physical minimum (e.g. docker container restart takes ~3-5s
+    regardless of how aggressively you scale)::
 
         wait_for(is_ha_ready, timeout=30, floor=10, msg="for HA to start")
-        # At WAIT_SCALE_POLL=0.05: scaled = max(30*0.05, 10) = 10s, not 1.5s
+        # At WAIT_SCALE_POLL=0.05: scaled = min(max(1.5, 10), 30) = 10s
+
+    The floor never makes the timeout *longer* than the original value —
+    it only protects against scaling too aggressively.
 
     The global ``WAIT_FLOOR_POLL`` also applies — the effective floor is
     ``max(floor, WAIT_FLOOR_POLL)``.
     """
     effective_floor = max(floor, WAIT_FLOOR_POLL)
-    scaled_timeout = max(timeout * WAIT_SCALE_POLL, effective_floor)
+    scaled_timeout = min(max(timeout * WAIT_SCALE_POLL, effective_floor), timeout)
     scaled_interval = max(0.1, interval * WAIT_SCALE_POLL)
     if scaled_timeout != timeout:
+        scaled_str = f"{scaled_timeout:g}"
         print(
-            f"  Waiting up to {timeout}s→{scaled_timeout:.0f}s {msg}...",
+            f"  Waiting up to {timeout}s→{scaled_str}s {msg}...",
             end="",
             flush=True,
         )
@@ -754,7 +763,7 @@ def wait_for(
         except Exception:
             pass  # condition may fail while HA is reloading
         time.sleep(scaled_interval)
-    print(f" TIMEOUT ({scaled_timeout:.0f}s)")
+    print(f" TIMEOUT ({scaled_timeout:g}s)")
     return False
 
 

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextvars
 import json
+import os
 import subprocess
 import time
 import urllib.error
@@ -25,6 +26,36 @@ from collections.abc import Callable
 from typing import Any
 
 from .const import InstanceConfig
+
+#: Scale factors for the two kinds of waits in the test suite.
+#:
+#: * ``WAIT_SCALE_BLIND`` — applied to every fixed ``wait()``/``ctx.wait()``
+#:   blind sleep.  These are the dominant cost (80 of 138 calls use 5s,
+#:   totalling ~400s), and also the riskiest to cut: 5s is already a
+#:   deliberate "let MQTT/HA settle" pause, so 5→0.5 is a 10x cut on
+#:   something that may genuinely need 2-3s.
+#:
+#: * ``WAIT_SCALE_POLL`` — applied to every ``wait_for()`` timeout ceiling.
+#:   These poll and return as soon as the condition is met, so the
+#:   timeout is just a safety margin.  On the simulator, conditions
+#:   typically resolve in 2-3s; if they haven't, the test has probably
+#:   failed.  Scaling 30s→3s just tightens the failure ceiling — safe to
+#:   cut aggressively.
+#:
+#: Both default to ``HA_SIM_TEST_WAIT_SCALE`` (the legacy single knob) if
+#: set, otherwise 1.0.  The per-bucket env vars take precedence when set.
+WAIT_SCALE_BLIND: float = float(
+    os.environ.get(
+        "HA_SIM_TEST_WAIT_SCALE_BLIND",
+        os.environ.get("HA_SIM_TEST_WAIT_SCALE", "1.0"),
+    )
+)
+WAIT_SCALE_POLL: float = float(
+    os.environ.get(
+        "HA_SIM_TEST_WAIT_SCALE_POLL",
+        os.environ.get("HA_SIM_TEST_WAIT_SCALE", "1.0"),
+    )
+)
 
 # ---------------------------------------------------------------------------
 # Current instance contextvar — asyncio-safe per-task instance selection
@@ -148,8 +179,40 @@ def call_service(
 # ---------------------------------------------------------------------------
 # Websocket API helpers (for profile loading)
 # ---------------------------------------------------------------------------
-async def ws_send(token: str, msg: dict) -> dict:
-    """Send a websocket message and return the response."""
+async def ws_send(token: str, msg: dict, *, retries: int = 2) -> dict:
+    """Send a websocket message and return the response.
+
+    Retries up to *retries* times with 3s backoff for transient timeouts
+    and connection errors (common under parallel container contention
+    where HA may be too busy to respond within the 30s websocket timeout).
+    """
+    import aiohttp
+
+    last_err: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            return await _ws_send_once(token, msg)
+        except (TimeoutError, aiohttp.ClientError, RuntimeError) as e:
+            last_err = e
+            err = str(e)
+            # Don't retry on "unknown_command" (ramses_extras not loaded yet)
+            # or on genuine WS error responses — only retry on timeouts and
+            # connection issues.
+            if "unknown_command" in err or "WS error:" in err:
+                raise
+            if attempt < retries:
+                import asyncio as _asyncio
+
+                print(
+                    f"  ws_send: retry {attempt + 1}/{retries}"
+                    f" ({type(e).__name__}: {err[:60]})"
+                )
+                await _asyncio.sleep(3)
+    raise last_err  # type: ignore[misc]
+
+
+async def _ws_send_once(token: str, msg: dict) -> dict:
+    """Single websocket send attempt (no retry)."""
     import aiohttp
 
     uri = get_current_instance().ws_url
@@ -605,9 +668,10 @@ def find_entity_for_device(
 
 
 def wait(seconds: int, msg: str = "") -> None:
-    """Wait and print progress."""
+    """Wait and print progress (scaled by ``WAIT_SCALE_BLIND``)."""
+    scaled = max(0.0, seconds * WAIT_SCALE_BLIND)
     print(f"  Waiting {seconds}s {msg}...", end="", flush=True)
-    time.sleep(seconds)
+    time.sleep(scaled)
     print(" done")
 
 
@@ -621,19 +685,24 @@ def wait_for(
 
     Checks *condition* every *interval* seconds.  Returns True if the
     condition was met within *timeout* seconds, False otherwise.
-    Prints progress like :func:`wait`.
+    Prints progress like :func:`wait`.  Both *timeout* and *interval*
+    are scaled by ``WAIT_SCALE_POLL`` — polling still exits as soon as
+    *condition* is met, so scaling down mainly tightens the safety
+    margin for genuinely slow conditions.
     """
+    scaled_timeout = max(0.0, timeout * WAIT_SCALE_POLL)
+    scaled_interval = max(0.1, interval * WAIT_SCALE_POLL)
     print(f"  Waiting up to {timeout}s {msg}...", end="", flush=True)
-    deadline = time.monotonic() + timeout
+    deadline = time.monotonic() + scaled_timeout
     while time.monotonic() < deadline:
         try:
             if condition():
-                print(f" done ({timeout - int(deadline - time.monotonic())}s)")
+                print(f" done ({int(scaled_timeout - (deadline - time.monotonic()))}s)")
                 return True
         except Exception:
             pass  # condition may fail while HA is reloading
-        time.sleep(interval)
-    print(f" TIMEOUT ({timeout}s)")
+        time.sleep(scaled_interval)
+    print(f" TIMEOUT ({scaled_timeout:.0f}s)")
     return False
 
 
@@ -652,6 +721,38 @@ def wait_for_schema_populated(min_keys: int = 5, timeout: int = 20) -> bool:
         timeout=timeout,
         interval=2,
         msg=f"for schema to have >= {min_keys} keys",
+    )
+
+
+def wait_for_transport_ready(timeout: int = 30) -> bool:
+    """Wait until the ramses_rf MQTT transport has reconnected after a reload.
+
+    After a profile reload with ``reload_ramses_cc=True``, the ramses_rf
+    transport closes and takes ~15-20s to reconnect.  Injected packets are
+    silently dropped ("Transport Error: Transport is closing or has closed")
+    during this window.  This helper polls the HA log for the
+    ``Subscribed to status topic`` message that indicates the MQTT transport
+    has reconnected and the FSM is back in ``IsInIdle``.
+    """
+    inst = get_current_instance()
+
+    def _check() -> bool:
+        result = subprocess.run(
+            ["docker", "logs", "--since", "5s", inst.name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return False
+        logs = result.stderr or ""
+        # The MQTT transport logs this when it (re)subscribes after connecting.
+        # Use a short --since window so we only catch the reconnection after
+        # the profile reload, not the initial startup message.
+        return "Subscribed to status topic" in logs
+
+    return wait_for(
+        _check, timeout=timeout, interval=3, msg="for transport to reconnect"
     )
 
 

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -777,6 +777,22 @@ def wait_for_ha_ready(timeout: int = 30, msg: str = "for ha-sim to start up") ->
     return wait_for(is_ha_ready, timeout=timeout, interval=2, msg=msg, floor=10.0)
 
 
+def wait_for_ramses_cc_loaded(
+    timeout: int = 30, msg: str = "for ramses_cc to initialize"
+) -> bool:
+    """Wait for ramses_cc to be loaded after a docker restart.
+
+    Like :func:`wait_for` with :func:`is_ramses_cc_loaded`, but with a
+    *floor* of 15s — after a docker restart, ramses_cc's async_setup_entry
+    takes 5-10s to complete (MQTT transport init, schema load, entity
+    creation).  Scaling the timeout below 15s causes false TIMEOUTs that
+    cascade into schema/profile load failures in subsequent steps.
+    """
+    return wait_for(
+        is_ramses_cc_loaded, timeout=timeout, interval=2, msg=msg, floor=15.0
+    )
+
+
 # ---------------------------------------------------------------------------
 # Composite wait helpers — poll for common conditions instead of fixed sleeps
 # ---------------------------------------------------------------------------
@@ -793,6 +809,56 @@ def wait_for_schema_populated(min_keys: int = 5, timeout: int = 20) -> bool:
         interval=2,
         msg=f"for schema to have >= {min_keys} keys",
     )
+
+
+def wait_for_schema_stable(
+    timeout: int = 10,
+    quiet: float = 1.0,
+    msg: str = "for schema to stabilise",
+) -> bool:
+    """Wait until the schema stops changing.
+
+    Polls the schema every 0.5s and returns as soon as two consecutive
+    reads produce the same JSON-serialised content (i.e. the schema has
+    been quiet for *quiet* seconds).  Replaces blind ``wait(5, "for
+    sync_learned_topology")`` and ``wait(5, "for save_client_state")``
+    calls — typically returns in 1-2s instead of sleeping the full 5s.
+
+    The *timeout* is the ceiling (scaled by ``WAIT_SCALE_POLL``); the
+    *quiet* window is the stability threshold (not scaled — it's a
+    real-time poll interval).
+    """
+    import json
+
+    def _schema_hash() -> str:
+        try:
+            return json.dumps(get_schema_retry(max_tries=1), sort_keys=True)
+        except Exception:
+            return ""
+
+    last = _schema_hash()
+    quiet_until = time.monotonic() + quiet
+    scaled_timeout = min(
+        max(timeout * WAIT_SCALE_POLL, max(WAIT_FLOOR_POLL, 3.0)), timeout
+    )
+    print(
+        f"  Waiting up to {timeout}s→{scaled_timeout:g}s {msg}...",
+        end="",
+        flush=True,
+    )
+    deadline = time.monotonic() + scaled_timeout
+    while time.monotonic() < deadline:
+        time.sleep(0.5)
+        current = _schema_hash()
+        if current == last and current:
+            if time.monotonic() >= quiet_until:
+                print(" done (stable)")
+                return True
+        else:
+            last = current
+            quiet_until = time.monotonic() + quiet
+    print(f" TIMEOUT ({scaled_timeout:g}s)")
+    return False
 
 
 def wait_for_transport_ready(timeout: int = 30) -> bool:

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -799,14 +799,15 @@ def wait_for_ramses_cc_reload(
     """Wait for ramses_cc to reload after a profile change (in-process).
 
     Like :func:`wait_for` with :func:`is_ramses_cc_loaded`, but with a
-    *floor* of 5s — profile reloads are in-process (no docker restart),
-    so they're faster than cold starts (typically 2-3s).  At aggressive
-    poll scales (0.1), the 20s ceiling would drop to 2s which is too
-    tight; the 5s floor ensures we don't give up before the reload
-    completes, while still returning early once it's done.
+    *floor* of 8s — profile reloads are in-process (no docker restart),
+    so they're faster than cold starts, but still take 5-7s for the
+    full reload cycle (unload → reload → MQTT reconnect → schema load).
+    At aggressive poll scales (0.1), the 20s ceiling would drop to 2s
+    which is too tight; the 8s floor ensures we don't give up before
+    the reload completes, while still returning early once it's done.
     """
     return wait_for(
-        is_ramses_cc_loaded, timeout=timeout, interval=1, msg=msg, floor=5.0
+        is_ramses_cc_loaded, timeout=timeout, interval=1, msg=msg, floor=8.0
     )
 
 
@@ -830,16 +831,22 @@ def wait_for_schema_populated(min_keys: int = 5, timeout: int = 20) -> bool:
 
 def wait_for_schema_stable(
     timeout: int = 10,
-    quiet: float = 1.0,
+    quiet: float = 1.5,
+    min_keys: int = 5,
     msg: str = "for schema to stabilise",
 ) -> bool:
-    """Wait until the schema stops changing.
+    """Wait until the schema stops changing and has enough keys.
 
     Polls the schema every 0.5s and returns as soon as two consecutive
     reads produce the same JSON-serialised content (i.e. the schema has
-    been quiet for *quiet* seconds).  Replaces blind ``wait(5, "for
+    been quiet for *quiet* seconds) AND the schema has at least
+    *min_keys* entries.  Replaces blind ``wait(5, "for
     sync_learned_topology")`` and ``wait(5, "for save_client_state")``
-    calls — typically returns in 1-2s instead of sleeping the full 5s.
+    calls — typically returns in 2-3s instead of sleeping the full 5s.
+
+    The *min_keys* guard prevents premature "stable" returns when the
+    schema is briefly empty after a profile reload (before heartbeats
+    repopulate it).
 
     The *timeout* is the ceiling (scaled by ``WAIT_SCALE_POLL``); the
     *quiet* window is the stability threshold (not scaled — it's a
@@ -849,7 +856,10 @@ def wait_for_schema_stable(
 
     def _schema_hash() -> str:
         try:
-            return json.dumps(get_schema_retry(max_tries=1), sort_keys=True)
+            schema = get_schema_retry(max_tries=1)
+            if len(schema) < min_keys:
+                return ""  # not enough keys yet — force unstable
+            return json.dumps(schema, sort_keys=True)
         except Exception:
             return ""
 

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -47,13 +47,13 @@ from .const import InstanceConfig
 WAIT_SCALE_BLIND: float = float(
     os.environ.get(
         "HA_SIM_TEST_WAIT_SCALE_BLIND",
-        os.environ.get("HA_SIM_TEST_WAIT_SCALE", "1.0"),
+        os.environ.get("HA_SIM_TEST_WAIT_SCALE", "0.5"),
     )
 )
 WAIT_SCALE_POLL: float = float(
     os.environ.get(
         "HA_SIM_TEST_WAIT_SCALE_POLL",
-        os.environ.get("HA_SIM_TEST_WAIT_SCALE", "1.0"),
+        os.environ.get("HA_SIM_TEST_WAIT_SCALE", "0.08"),
     )
 )
 
@@ -70,7 +70,7 @@ WAIT_SCALE_POLL: float = float(
 #: ``WAIT_FLOOR_POLL`` does the same for ``wait_for()`` timeout ceilings.
 #: The per-call ``floor=`` parameter (e.g. ``wait_for_ha_ready`` uses floor=10)
 #: takes the max with this global floor.
-WAIT_FLOOR_BLIND: float = float(os.environ.get("HA_SIM_TEST_WAIT_FLOOR_BLIND", "0"))
+WAIT_FLOOR_BLIND: float = float(os.environ.get("HA_SIM_TEST_WAIT_FLOOR_BLIND", "3"))
 WAIT_FLOOR_POLL: float = float(os.environ.get("HA_SIM_TEST_WAIT_FLOOR_POLL", "0"))
 
 # ---------------------------------------------------------------------------

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -917,7 +917,11 @@ def wait_for_transport_ready(timeout: int = 30) -> bool:
         return "Subscribed to status topic" in logs
 
     return wait_for(
-        _check, timeout=timeout, interval=3, msg="for transport to reconnect"
+        _check,
+        timeout=timeout,
+        interval=3,
+        msg="for transport to reconnect",
+        floor=3.0,
     )
 
 
@@ -943,7 +947,11 @@ def wait_for_schema_has(
         return True
 
     return wait_for(
-        _check, timeout=timeout, interval=2, msg=f"for {device_id} in schema"
+        _check,
+        timeout=timeout,
+        interval=2,
+        msg=f"for {device_id} in schema",
+        floor=3.0,
     )
 
 
@@ -988,6 +996,7 @@ def wait_for_entity_state(
         interval=1,
         msg=f"for {entity_id} state"
         + (f" == {expected!r}" if expected else " to be set"),
+        floor=3.0,
     )
 
 

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -793,6 +793,23 @@ def wait_for_ramses_cc_loaded(
     )
 
 
+def wait_for_ramses_cc_reload(
+    timeout: int = 20, msg: str = "for ramses_cc reload"
+) -> bool:
+    """Wait for ramses_cc to reload after a profile change (in-process).
+
+    Like :func:`wait_for` with :func:`is_ramses_cc_loaded`, but with a
+    *floor* of 5s — profile reloads are in-process (no docker restart),
+    so they're faster than cold starts (typically 2-3s).  At aggressive
+    poll scales (0.1), the 20s ceiling would drop to 2s which is too
+    tight; the 5s floor ensures we don't give up before the reload
+    completes, while still returning early once it's done.
+    """
+    return wait_for(
+        is_ramses_cc_loaded, timeout=timeout, interval=1, msg=msg, floor=5.0
+    )
+
+
 # ---------------------------------------------------------------------------
 # Composite wait helpers — poll for common conditions instead of fixed sleeps
 # ---------------------------------------------------------------------------

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -826,6 +826,7 @@ def wait_for_schema_populated(min_keys: int = 5, timeout: int = 20) -> bool:
         timeout=timeout,
         interval=2,
         msg=f"for schema to have >= {min_keys} keys",
+        floor=3.0,
     )
 
 

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -57,6 +57,22 @@ WAIT_SCALE_POLL: float = float(
     )
 )
 
+#: Global minimum floors (seconds, pre-scaling) that all scaled waits respect.
+#: Unlike the per-call ``floor=`` parameter (which takes the max with these),
+#: these apply to *every* wait in the suite.  Set via env var or CLI flag.
+#:
+#: ``WAIT_FLOOR_BLIND`` ensures every blind sleep is at least N seconds real
+#: time, regardless of ``WAIT_SCALE_BLIND``.  Useful when running at aggressive
+#: scale factors: e.g. ``--wait-scale-blind 0.5 --wait-floor-blind 3`` means
+#: ``wait(5)`` → max(2.5, 3) = 3s, ``wait(10)`` → max(5, 3) = 5s, but
+#: ``wait(2)`` → max(1, 3) = 3s (slightly over, but safe).
+#:
+#: ``WAIT_FLOOR_POLL`` does the same for ``wait_for()`` timeout ceilings.
+#: The per-call ``floor=`` parameter (e.g. ``wait_for_ha_ready`` uses floor=10)
+#: takes the max with this global floor.
+WAIT_FLOOR_BLIND: float = float(os.environ.get("HA_SIM_TEST_WAIT_FLOOR_BLIND", "0"))
+WAIT_FLOOR_POLL: float = float(os.environ.get("HA_SIM_TEST_WAIT_FLOOR_POLL", "0"))
+
 # ---------------------------------------------------------------------------
 # Current instance contextvar — asyncio-safe per-task instance selection
 # ---------------------------------------------------------------------------
@@ -667,10 +683,25 @@ def find_entity_for_device(
     return None
 
 
-def wait(seconds: int, msg: str = "") -> None:
-    """Wait and print progress (scaled by ``WAIT_SCALE_BLIND``)."""
-    scaled = max(0.0, seconds * WAIT_SCALE_BLIND)
-    print(f"  Waiting {seconds}s {msg}...", end="", flush=True)
+def wait(seconds: int, msg: str = "", *, floor: float = 0.0) -> None:
+    """Wait and print progress (scaled by ``WAIT_SCALE_BLIND``).
+
+    *floor* sets a minimum absolute sleep (seconds, pre-scaling) that the
+    scaled sleep will not go below — use it for sensitive waits that need
+    a hard minimum regardless of the global scale factor::
+
+        wait(5, "for scan engine", floor=3)
+        # At WAIT_SCALE_BLIND=0.5: scaled = max(5*0.5, 3) = 3s, not 2.5s
+
+    The global ``WAIT_FLOOR_BLIND`` also applies — the effective floor is
+    ``max(floor, WAIT_FLOOR_BLIND)``.
+    """
+    effective_floor = max(floor, WAIT_FLOOR_BLIND)
+    scaled = max(seconds * WAIT_SCALE_BLIND, effective_floor)
+    if scaled != seconds:
+        print(f"  Waiting {seconds}s→{scaled:.0f}s {msg}...", end="", flush=True)
+    else:
+        print(f"  Waiting {seconds}s {msg}...", end="", flush=True)
     time.sleep(scaled)
     print(" done")
 
@@ -680,6 +711,8 @@ def wait_for(
     timeout: int = 30,
     interval: float = 1.0,
     msg: str = "",
+    *,
+    floor: float = 0.0,
 ) -> bool:
     """Poll a condition until True or timeout.
 
@@ -689,10 +722,29 @@ def wait_for(
     are scaled by ``WAIT_SCALE_POLL`` — polling still exits as soon as
     *condition* is met, so scaling down mainly tightens the safety
     margin for genuinely slow conditions.
+
+    *floor* sets a minimum absolute timeout (in seconds, before scaling)
+    that the scaled timeout will not go below.  Use it for waits that
+    have a hard physical minimum (e.g. docker container restart takes
+    ~3-5s regardless of how aggressively you scale)::
+
+        wait_for(is_ha_ready, timeout=30, floor=10, msg="for HA to start")
+        # At WAIT_SCALE_POLL=0.05: scaled = max(30*0.05, 10) = 10s, not 1.5s
+
+    The global ``WAIT_FLOOR_POLL`` also applies — the effective floor is
+    ``max(floor, WAIT_FLOOR_POLL)``.
     """
-    scaled_timeout = max(0.0, timeout * WAIT_SCALE_POLL)
+    effective_floor = max(floor, WAIT_FLOOR_POLL)
+    scaled_timeout = max(timeout * WAIT_SCALE_POLL, effective_floor)
     scaled_interval = max(0.1, interval * WAIT_SCALE_POLL)
-    print(f"  Waiting up to {timeout}s {msg}...", end="", flush=True)
+    if scaled_timeout != timeout:
+        print(
+            f"  Waiting up to {timeout}s→{scaled_timeout:.0f}s {msg}...",
+            end="",
+            flush=True,
+        )
+    else:
+        print(f"  Waiting up to {timeout}s {msg}...", end="", flush=True)
     deadline = time.monotonic() + scaled_timeout
     while time.monotonic() < deadline:
         try:
@@ -704,6 +756,16 @@ def wait_for(
         time.sleep(scaled_interval)
     print(f" TIMEOUT ({scaled_timeout:.0f}s)")
     return False
+
+
+def wait_for_ha_ready(timeout: int = 30, msg: str = "for ha-sim to start up") -> bool:
+    """Wait for HA to be ready after a docker restart.
+
+    Like :func:`wait_for` with :func:`is_ha_ready`, but with a *floor*
+    of 10s — docker restarts take a hard 3-5s minimum before the API is
+    even reachable, so scaling the timeout below 10s makes no sense.
+    """
+    return wait_for(is_ha_ready, timeout=timeout, interval=2, msg=msg, floor=10.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ha_sim_test/helpers.py
+++ b/tools/ha_sim_test/helpers.py
@@ -903,7 +903,7 @@ def wait_for_transport_ready(timeout: int = 30) -> bool:
 
     def _check() -> bool:
         result = subprocess.run(
-            ["docker", "logs", "--since", "5s", inst.name],
+            ["docker", "logs", "--since", "2s", inst.name],
             capture_output=True,
             text=True,
             timeout=10,
@@ -912,8 +912,8 @@ def wait_for_transport_ready(timeout: int = 30) -> bool:
             return False
         logs = result.stderr or ""
         # The MQTT transport logs this when it (re)subscribes after connecting.
-        # Use a short --since window so we only catch the reconnection after
-        # the profile reload, not the initial startup message.
+        # Use a short --since window (2s) so we only catch the reconnection
+        # after the profile reload, not a stale message from a previous reload.
         return "Subscribed to status topic" in logs
 
     return wait_for(
@@ -921,7 +921,7 @@ def wait_for_transport_ready(timeout: int = 30) -> bool:
         timeout=timeout,
         interval=3,
         msg="for transport to reconnect",
-        floor=3.0,
+        floor=15.0,
     )
 
 

--- a/tools/ha_sim_test/parallel.py
+++ b/tools/ha_sim_test/parallel.py
@@ -294,7 +294,9 @@ async def ensure_containers(instances: list[InstanceConfig]) -> None:
             finally:
                 _current_instance_reset(token)
 
-        ready = wait_for(_ready, timeout=120, interval=3, msg=f"[{inst.name}] HA ready")
+        ready = wait_for(
+            _ready, timeout=120, interval=3, msg=f"[{inst.name}] HA ready", floor=15.0
+        )
         if not ready:
             raise RuntimeError(f"[{inst.name}] HA did not become ready within 120s")
         print(f"  [{inst.name}] HA is ready")

--- a/tools/ha_sim_test/parallel.py
+++ b/tools/ha_sim_test/parallel.py
@@ -238,12 +238,35 @@ def generate_compose_file(instances: list[InstanceConfig]) -> str:
 async def ensure_containers(instances: list[InstanceConfig]) -> None:
     """Start all parallel containers.
 
-    Instance 1 (ha-sim) is assumed to be already running.
-    Instances 2+ are cloned from the base config and started via docker-compose.
+    Instance 1 (ha-sim) is assumed to be already running, but we verify
+    it's reachable and wait up to 30s if not.  Instances 2+ are cloned
+    from the base config and started via docker-compose.
     If a container is already running and healthy, it is reused as-is
     (warm start — skips clone and HA readiness wait).
     """
     log_section("Parallel: Starting containers")
+
+    # Verify instance 1 (ha-sim) is reachable — it's not started by us
+    inst1 = instances[0]
+    print(f"  [{inst1.name}] Verifying HA is reachable on port {inst1.port}...")
+
+    def _ready1(inst: InstanceConfig = inst1) -> bool:
+        token = set_current_instance(inst)
+        try:
+            return is_ha_ready()
+        finally:
+            _current_instance_reset(token)
+
+    ready1 = wait_for(
+        _ready1, timeout=30, interval=2, msg=f"[{inst1.name}] HA ready", floor=10.0
+    )
+    if not ready1:
+        raise RuntimeError(
+            f"[{inst1.name}] is not reachable on port {inst1.port}. "
+            f"Start it first: cd ~/docker_files/ha-sim && docker compose up -d"
+        )
+    print(f"  [{inst1.name}] HA is ready")
+
     parallel_instances = instances[1:]
     if not parallel_instances:
         return

--- a/tools/ha_sim_test/parallel.py
+++ b/tools/ha_sim_test/parallel.py
@@ -18,6 +18,7 @@ The runner:
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
 import re
 import subprocess
@@ -28,6 +29,7 @@ from typing import Any
 
 from .base import RecipeContext
 from .const import InstanceConfig, make_instances
+from .dashboard import LiveDashboard
 from .helpers import (
     _current_instance as _current_instance_var,
 )
@@ -888,12 +890,28 @@ async def run_parallel(
             f" {', '.join(rids[:10])}{'...' if len(rids) > 10 else ''}"
         )
 
-    # Run in parallel
+    # Run in parallel, with a live per-container status dashboard (falls
+    # back to plain interleaved prints when stdout isn't a real terminal,
+    # e.g. piped to a log file).
     log_section("Parallel: Running recipes")
-    tasks = [
-        run_single_instance(instances[idx - 1], groups[idx]) for idx in sorted(groups)
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+    ordered_instances = [instances[idx - 1] for idx in sorted(groups)]
+    dash = LiveDashboard([inst.name for inst in ordered_instances])
+    tasks: list[asyncio.Task[InstanceResult]] = []
+
+    def _on_done(_task: asyncio.Task[InstanceResult], name: str) -> None:
+        dash.mark_done(name)
+
+    for idx in sorted(groups):
+        inst = instances[idx - 1]
+        task = asyncio.ensure_future(run_single_instance(inst, groups[idx]))
+        task.add_done_callback(functools.partial(_on_done, name=inst.name))
+        tasks.append(task)
+
+    dash.start()
+    try:
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+    finally:
+        await dash.stop()
 
     # Handle exceptions from gather
     final_results: list[InstanceResult] = []

--- a/tools/ha_sim_test/recipes/r01_activate_heat_profile_verify_schema_entities_a.py
+++ b/tools/ha_sim_test/recipes/r01_activate_heat_profile_verify_schema_entities_a.py
@@ -71,7 +71,7 @@ class R01ActivateHeatProfileVerifySchemaEntitiesA(Recipe):
             print("  heat_only profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {str(e)[:80]}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate CTL, TRV, DHW
         for dev, slug in [(CTL, "CTL"), ("04:150000", "TRV"), (DHW, "DHW")]:

--- a/tools/ha_sim_test/recipes/r05_no_resurrection_after_restart.py
+++ b/tools/ha_sim_test/recipes/r05_no_resurrection_after_restart.py
@@ -58,7 +58,7 @@ class R05NoResurrectionAfterRestart(Recipe):
         # in-memory options match .storage (remove_device reads from
         # coordinator.options, not .storage).
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
 
         # TRV and CTL were removed in recipes 2/4.  The 7b profile reload brings
         # them back (mixed profile includes them in known_list).  Re-remove them
@@ -92,12 +92,12 @@ class R05NoResurrectionAfterRestart(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         # Wait for .storage to be flushed — HA doesn't flush immediately
         # after async_update_entry.  Retry for up to 30s.

--- a/tools/ha_sim_test/recipes/r06_zone_binding_via_inject_message.py
+++ b/tools/ha_sim_test/recipes/r06_zone_binding_via_inject_message.py
@@ -85,14 +85,14 @@ class R06ZoneBindingViaInjectMessage(Recipe):
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
 
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
 
         # Trigger a save to persist the synced schema to .storage
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         # Use cached schema (more reliable than config entry during sync)
         schema_after_inject = get_cached_schema()

--- a/tools/ha_sim_test/recipes/r06_zone_binding_via_inject_message.py
+++ b/tools/ha_sim_test/recipes/r06_zone_binding_via_inject_message.py
@@ -76,7 +76,7 @@ class R06ZoneBindingViaInjectMessage(Recipe):
             print(f"  Inject failed: {e}")
 
         # Wait for the 000C packet to be received and processed by ramses_rf
-        ctx.wait(5, "for 000C packet to be processed by ramses_rf")
+        ctx.wait(5, "for 000C packet to be processed by ramses_rf", floor=2.0)
 
         # Trigger sync_topology to process the injected packet
         try:

--- a/tools/ha_sim_test/recipes/r07_hvac_schema_caching_verify_fan_in_schema_cache.py
+++ b/tools/ha_sim_test/recipes/r07_hvac_schema_caching_verify_fan_in_schema_cache.py
@@ -57,7 +57,7 @@ class R07HvacSchemaCachingVerifyFanInSchemaCache(Recipe):
         except RuntimeError as e:
             print(f"  force_update failed: {e}")
 
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         storage = get_ramses_storage()
         hvac_schema = storage.get("hvac_schema", {})

--- a/tools/ha_sim_test/recipes/r07b_restart_and_verify_hvac_survives.py
+++ b/tools/ha_sim_test/recipes/r07b_restart_and_verify_hvac_survives.py
@@ -77,7 +77,7 @@ class R07bRestartAndVerifyHvacSurvives(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Mixed profile reload failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Re-activate devices (profile reload stops all active devices)
         for dev_id, name in [(FAN, "FAN"), (REM, "REM"), (CO2, "CO2")]:

--- a/tools/ha_sim_test/recipes/r07b_restart_and_verify_hvac_survives.py
+++ b/tools/ha_sim_test/recipes/r07b_restart_and_verify_hvac_survives.py
@@ -24,10 +24,10 @@ from ..helpers import (
     get_ramses_storage,
     get_schema,
     get_schema_retry,
-    is_ha_ready,
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
+    wait_for_ha_ready,
     wait_for_schema_populated,
     write_ramses_storage,
     ws_send,
@@ -50,7 +50,7 @@ class R07bRestartAndVerifyHvacSurvives(Recipe):
         subprocess.run(
             ["docker", "restart", get_current_instance().name], capture_output=True
         )
-        wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        wait_for_ha_ready(timeout=30)
 
         # Reset log baseline — logs are wiped by the restart
         ctx.log_monitor.reset_baseline()

--- a/tools/ha_sim_test/recipes/r08_hvac_schema_caching_merge_union_on_reload.py
+++ b/tools/ha_sim_test/recipes/r08_hvac_schema_caching_merge_union_on_reload.py
@@ -53,7 +53,7 @@ class R08HvacSchemaCachingMergeUnionOnReload(Recipe):
         except RuntimeError as e:
             print(f"  Profile load failed: {str(e)[:80]}")
 
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Verify both REMs are in the FAN's schema after reload
         schema_r8 = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r09_user_schema_edits_survive_sync__alias.py
+++ b/tools/ha_sim_test/recipes/r09_user_schema_edits_survive_sync__alias.py
@@ -59,7 +59,7 @@ class R09UserSchemaEditsSurviveSyncAlias(Recipe):
         except RuntimeError as e:
             print(f"  Profile load failed: {str(e)[:80]}")
 
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Verify _alias is present before sync
         schema_before_sync = get_schema()

--- a/tools/ha_sim_test/recipes/r09_user_schema_edits_survive_sync__alias.py
+++ b/tools/ha_sim_test/recipes/r09_user_schema_edits_survive_sync__alias.py
@@ -82,12 +82,12 @@ class R09UserSchemaEditsSurviveSyncAlias(Recipe):
             print("  sync_topology called")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         # Verify _alias survived sync (check config entry schema)
         schema_r9 = get_schema()

--- a/tools/ha_sim_test/recipes/r10_invalid_main_tcs_safety_net.py
+++ b/tools/ha_sim_test/recipes/r10_invalid_main_tcs_safety_net.py
@@ -55,7 +55,7 @@ class R10InvalidMainTcsSafetyNet(Recipe):
         except RuntimeError as e:
             print(f"  Profile load failed: {str(e)[:80]}")
 
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Debug: check what the config entry looks like
         schema_debug = get_schema()

--- a/tools/ha_sim_test/recipes/r10_invalid_main_tcs_safety_net.py
+++ b/tools/ha_sim_test/recipes/r10_invalid_main_tcs_safety_net.py
@@ -79,8 +79,24 @@ class R10InvalidMainTcsSafetyNet(Recipe):
             "sanitisation warning not found in logs",
         )
 
-        # Verify main_tcs is cleared (the invalid value 04:999999 should be gone;
-        # sync_learned_topology may re-derive main_tcs=01:150000 which is valid)
+        # Verify main_tcs is cleared (the invalid value 04:999999 should be
+        # gone; sync_learned_topology may re-derive main_tcs=01:150000 which
+        # is valid).  Poll for the sanitised schema — async_update_entry
+        # schedules an async save to .storage, so the file may not reflect
+        # the sanitisation immediately after reload.
+        def _main_tcs_cleared() -> bool:
+            schema = get_schema()
+            if not schema:
+                return False
+            mt = schema.get("main_tcs")
+            return mt != "04:999999" and "04:999999" not in json.dumps(schema)
+
+        ctx.wait_for(
+            _main_tcs_cleared,
+            timeout=10,
+            interval=1,
+            msg="for sanitised schema to persist",
+        )
         schema_after_sanitise = get_schema_retry()
         main_tcs_after = schema_after_sanitise.get("main_tcs")
         ctx.check(

--- a/tools/ha_sim_test/recipes/r11_full_lifecycle_discover_accept_remove.py
+++ b/tools/ha_sim_test/recipes/r11_full_lifecycle_discover_accept_remove.py
@@ -63,7 +63,7 @@ class R11FullLifecycleDiscoverAcceptRemove(Recipe):
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
 
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
 
         # Inject several 1FC9 heartbeats from the new TRV to trigger discovery
         print(f"  Injecting 1FC9 heartbeats from {new_trv}...")
@@ -195,6 +195,6 @@ class R11FullLifecycleDiscoverAcceptRemove(Recipe):
                     "enable_auto_answer": True,
                 },
             )
-            wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+            ctx.wait_for_ramses_cc_reload(timeout=20)
         except RuntimeError as e:
             print(f"  Mixed profile reload failed: {e}")

--- a/tools/ha_sim_test/recipes/r14_inject_raw_packet_zone_binding_change_a.py
+++ b/tools/ha_sim_test/recipes/r14_inject_raw_packet_zone_binding_change_a.py
@@ -72,12 +72,12 @@ class R14InjectRawPacketZoneBindingChangeA(Recipe):
             print("  sync_topology called")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         schema_r14 = get_schema_retry()
         ctl_r14 = schema_r14.get(CTL, {})

--- a/tools/ha_sim_test/recipes/r14_inject_raw_packet_zone_binding_change_a.py
+++ b/tools/ha_sim_test/recipes/r14_inject_raw_packet_zone_binding_change_a.py
@@ -65,7 +65,7 @@ class R14InjectRawPacketZoneBindingChangeA(Recipe):
             print("  000C packet injected")
         except RuntimeError as e:
             print(f"  Inject failed: {e}")
-        ctx.wait(5, "for 000C packet processing")
+        ctx.wait(5, "for 000C packet processing", floor=2.0)
 
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")

--- a/tools/ha_sim_test/recipes/r16_concurrencystress_test_rapid_addremove_inject.py
+++ b/tools/ha_sim_test/recipes/r16_concurrencystress_test_rapid_addremove_inject.py
@@ -141,14 +141,23 @@ class R16ConcurrencystressTestRapidAddremoveInject(Recipe):
             capture_output=True,
             text=True,
         )
-        has_errors = "ERROR" in log_result.stderr or "Traceback" in log_result.stderr
-        # Filter out expected warnings (not errors)
+        # Filter out expected/cosmetic patterns (same list as log_monitor.py)
+        from ..log_monitor import EXPECTED_WARNINGS
+
+        def _is_expected(line: str) -> bool:
+            return any(pat in line for pat in EXPECTED_WARNINGS)
+
         real_errors = False
-        if has_errors:
-            for line in log_result.stderr.splitlines():
-                if "ERROR" in line and "ramses_cc" in line:
-                    real_errors = True
-                    break
+        for line in log_result.stderr.splitlines():
+            if "ERROR" not in line:
+                continue
+            if "ramses_cc" not in line and "ramses_rf" not in line:
+                continue
+            if _is_expected(line):
+                continue
+            real_errors = True
+            print(f"    ERROR: {line.strip()[:120]}")
+            break
         ctx.check(
             "No ramses_cc ERROR logs during stress test",
             not real_errors,

--- a/tools/ha_sim_test/recipes/r17_discovery_service_lifecycle_a.py
+++ b/tools/ha_sim_test/recipes/r17_discovery_service_lifecycle_a.py
@@ -58,7 +58,7 @@ class R17DiscoveryServiceLifecycleA(Recipe):
             print("  fresh_start profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Inject heartbeat from a new device to trigger discovery
         disc_dev = "04:500001"

--- a/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
+++ b/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
@@ -49,6 +49,11 @@ class R19ZoneBindingFromBroadcastTrafficPassiveScanA(Recipe):
         # the mixed profile (which has CTL + FAN + REM) instead of fresh_start.
 
         # Load mixed profile (has CTL for zone creation)
+        # Use reload_ramses_cc=False to avoid restarting the ramses_rf MQTT
+        # transport, which can destabilise on warm-started containers (the
+        # broker disconnects the new client before the old one is cleaned up).
+        # The mixed profile is already loaded in the setup phase; this reload
+        # just ensures a clean schema without breaking the transport.
         print("  Loading mixed profile (has CTL for zone creation)...")
         try:
             await ws_send(
@@ -58,7 +63,7 @@ class R19ZoneBindingFromBroadcastTrafficPassiveScanA(Recipe):
                     "profile": "mixed",
                     "speed": 0.01,
                     "preload_schema": True,
-                    "reload_ramses_cc": True,
+                    "reload_ramses_cc": False,
                     "enable_auto_answer": True,
                 },
             )

--- a/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
+++ b/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
@@ -70,7 +70,7 @@ class R19ZoneBindingFromBroadcastTrafficPassiveScanA(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate CTL for heartbeats
         try:

--- a/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
+++ b/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
@@ -136,7 +136,7 @@ class R19ZoneBindingFromBroadcastTrafficPassiveScanA(Recipe):
                 print(f"    {trv_id} -> 3150: FAILED - {str(e)[:80]}")
             time.sleep(0.5)
 
-        ctx.wait(3, "for scan engine to process", floor=2.0)
+        ctx.wait(5, "for scan engine to process", floor=4.0)
 
         # Accept the discovered TRVs so they enter the known_list.
         # With the mixed profile (enforce_known_list=True), unknown devices

--- a/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
+++ b/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
@@ -161,12 +161,12 @@ class R19ZoneBindingFromBroadcastTrafficPassiveScanA(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         # Check that zones were created from broadcast traffic
         schema_r19 = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
+++ b/tools/ha_sim_test/recipes/r19_zone_binding_from_broadcast_traffic_passive_scan_a.py
@@ -136,7 +136,7 @@ class R19ZoneBindingFromBroadcastTrafficPassiveScanA(Recipe):
                 print(f"    {trv_id} -> 3150: FAILED - {str(e)[:80]}")
             time.sleep(0.5)
 
-        ctx.wait(3, "for scan engine to process")
+        ctx.wait(3, "for scan engine to process", floor=2.0)
 
         # Accept the discovered TRVs so they enter the known_list.
         # With the mixed profile (enforce_known_list=True), unknown devices

--- a/tools/ha_sim_test/recipes/r19b_invalid_zone_indices_are_rejected_a.py
+++ b/tools/ha_sim_test/recipes/r19b_invalid_zone_indices_are_rejected_a.py
@@ -61,12 +61,12 @@ class R19bInvalidZoneIndicesAreRejectedA(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r19b = get_schema_retry()
         ctl_r19b = schema_r19b.get(CTL, {})

--- a/tools/ha_sim_test/recipes/r19b_invalid_zone_indices_are_rejected_a.py
+++ b/tools/ha_sim_test/recipes/r19b_invalid_zone_indices_are_rejected_a.py
@@ -56,7 +56,7 @@ class R19bInvalidZoneIndicesAreRejectedA(Recipe):
         except RuntimeError as e:
             print(f"  Inject failed: {e}")
 
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r19c_18_hgi_devices_tracked_but_no_zone_bindings_a.py
+++ b/tools/ha_sim_test/recipes/r19c_18_hgi_devices_tracked_but_no_zone_bindings_a.py
@@ -62,12 +62,12 @@ class R19c18HgiDevicesTrackedButNoZoneBindingsA(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r19c = get_schema_retry()
         ctl_r19c = schema_r19c.get(CTL, {})

--- a/tools/ha_sim_test/recipes/r19c_18_hgi_devices_tracked_but_no_zone_bindings_a.py
+++ b/tools/ha_sim_test/recipes/r19c_18_hgi_devices_tracked_but_no_zone_bindings_a.py
@@ -57,7 +57,7 @@ class R19c18HgiDevicesTrackedButNoZoneBindingsA(Recipe):
         except RuntimeError as e:
             print(f"  Inject failed: {e}")
 
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r20_ssot_phase_2_migration_known_list_traits_to_schema.py
+++ b/tools/ha_sim_test/recipes/r20_ssot_phase_2_migration_known_list_traits_to_schema.py
@@ -70,12 +70,12 @@ class R20SsotPhase2MigrationKnownListTraitsToSchema(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r20 = get_schema_retry()
 

--- a/tools/ha_sim_test/recipes/r21_ctl_01_does_not_get_zone_idx_from_000a_packets.py
+++ b/tools/ha_sim_test/recipes/r21_ctl_01_does_not_get_zone_idx_from_000a_packets.py
@@ -60,7 +60,7 @@ class R21Ctl01DoesNotGetZoneIdxFrom000aPackets(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Inject 000A from CTL with zone 02 payload
         # 000A I payload: zone_idx(2) + bitmap(2) + min_temp(4) + max_temp(4) = 12 hex

--- a/tools/ha_sim_test/recipes/r21_ctl_01_does_not_get_zone_idx_from_000a_packets.py
+++ b/tools/ha_sim_test/recipes/r21_ctl_01_does_not_get_zone_idx_from_000a_packets.py
@@ -102,7 +102,7 @@ class R21Ctl01DoesNotGetZoneIdxFrom000aPackets(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r21_ctl_01_does_not_get_zone_idx_from_000a_packets.py
+++ b/tools/ha_sim_test/recipes/r21_ctl_01_does_not_get_zone_idx_from_000a_packets.py
@@ -107,12 +107,12 @@ class R21Ctl01DoesNotGetZoneIdxFrom000aPackets(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r21 = get_schema_retry()
         comments_r21 = schema_r21.get("device_comments", {})

--- a/tools/ha_sim_test/recipes/r22_thm_22_zone_binding_via_000a.py
+++ b/tools/ha_sim_test/recipes/r22_thm_22_zone_binding_via_000a.py
@@ -109,12 +109,12 @@ class R22Thm22ZoneBindingVia000a(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r22 = get_schema_retry()
         comments_r22 = schema_r22.get("device_comments", {})

--- a/tools/ha_sim_test/recipes/r22_thm_22_zone_binding_via_000a.py
+++ b/tools/ha_sim_test/recipes/r22_thm_22_zone_binding_via_000a.py
@@ -104,7 +104,7 @@ class R22Thm22ZoneBindingVia000a(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(3, "for scan engine to process")
+        ctx.wait(3, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r22_thm_22_zone_binding_via_000a.py
+++ b/tools/ha_sim_test/recipes/r22_thm_22_zone_binding_via_000a.py
@@ -60,7 +60,7 @@ class R22Thm22ZoneBindingVia000a(Recipe):
             print("  fresh_start profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Inject RQ 000A from a THM (22:) to the HGI (18:001234)
         # THMs send RQ 000A with just the zone_idx (2 hex) as payload.

--- a/tools/ha_sim_test/recipes/r23_0004_zone_name_propagation_parser_0004_zone_idx_fi.py
+++ b/tools/ha_sim_test/recipes/r23_0004_zone_name_propagation_parser_0004_zone_idx_fi.py
@@ -117,7 +117,7 @@ class R230004ZoneNamePropagationParser0004ZoneIdxFi(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r23_0004_zone_name_propagation_parser_0004_zone_idx_fi.py
+++ b/tools/ha_sim_test/recipes/r23_0004_zone_name_propagation_parser_0004_zone_idx_fi.py
@@ -62,7 +62,7 @@ class R230004ZoneNamePropagationParser0004ZoneIdxFi(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 0004 payload format: zone_idx(2) + "00"(2) + name_hex(40, 20 bytes
         # ASCII padded with 00).  Total = 44 hex chars (22 bytes, length 022).

--- a/tools/ha_sim_test/recipes/r23_0004_zone_name_propagation_parser_0004_zone_idx_fi.py
+++ b/tools/ha_sim_test/recipes/r23_0004_zone_name_propagation_parser_0004_zone_idx_fi.py
@@ -122,12 +122,12 @@ class R230004ZoneNamePropagationParser0004ZoneIdxFi(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         # Check: the 0004 packets were processed by the scan engine.
         # We check the HA log for the dispatcher entries showing our injected

--- a/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
+++ b/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
@@ -105,7 +105,7 @@ class R24Phase3cClassMismatchFlagging(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for mismatch detection")
+        ctx.wait(5, "for mismatch detection", floor=3.0)
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
+++ b/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
@@ -98,7 +98,7 @@ class R24Phase3cClassMismatchFlagging(Recipe):
                     f" {str(e)[:80]}"
                 )
                 ctx.wait(3, "before retry")
-        ctx.wait(5, "for FAN heartbeat to reach scan engine")
+        ctx.wait(5, "for FAN heartbeat to reach scan engine", floor=2.0)
 
         # Force a sync cycle to trigger mismatch detection
         try:

--- a/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
+++ b/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
@@ -98,14 +98,14 @@ class R24Phase3cClassMismatchFlagging(Recipe):
                     f" {str(e)[:80]}"
                 )
                 ctx.wait(3, "before retry")
-        ctx.wait(5, "for FAN heartbeat to reach scan engine", floor=2.0)
+        ctx.wait(5, "for FAN heartbeat to reach scan engine", floor=4.0)
 
         # Force a sync cycle to trigger mismatch detection
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for mismatch detection", floor=3.0)
+        ctx.wait(5, "for mismatch detection", floor=4.0)
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
+++ b/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
@@ -70,7 +70,7 @@ class R24Phase3cClassMismatchFlagging(Recipe):
         }
         mismatch_yaml = _yaml.dump(profile, default_flow_style=False, sort_keys=False)
         await load_profile_yaml(ctx.token, mismatch_yaml, speed=0.01)
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for profile reload")
+        ctx.wait_for_ramses_cc_reload(msg="for profile reload")
         ctx.refresh_token()
         # Inject a 1FC9 heartbeat from the FAN so the scan engine tracks
         # 32:150000 and can detect the _class=DIS mismatch.  The profile

--- a/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
+++ b/tools/ha_sim_test/recipes/r24_phase_3c_class_mismatch_flagging.py
@@ -110,7 +110,7 @@ class R24Phase3cClassMismatchFlagging(Recipe):
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         # Check 1: FAN remote entity should have class_mismatch attribute
         # The remote entity (remote.fan_32_150000) inherits from RamsesEntity

--- a/tools/ha_sim_test/recipes/r25_phase_3c_fix_mismatch_notification_dismissed.py
+++ b/tools/ha_sim_test/recipes/r25_phase_3c_fix_mismatch_notification_dismissed.py
@@ -79,7 +79,7 @@ class R25Phase3cFixMismatchNotificationDismissed(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for mismatch recheck")
+        ctx.wait(5, "for mismatch recheck", floor=3.0)
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r25_phase_3c_fix_mismatch_notification_dismissed.py
+++ b/tools/ha_sim_test/recipes/r25_phase_3c_fix_mismatch_notification_dismissed.py
@@ -73,7 +73,7 @@ class R25Phase3cFixMismatchNotificationDismissed(Recipe):
         }
         fixed_yaml = mixed_yaml(fixed_schema)
         await load_profile_yaml(ctx.token, fixed_yaml, speed=0.01)
-        wait_for(is_ramses_cc_loaded, timeout=10, msg="for profile reload")
+        ctx.wait_for_ramses_cc_reload(msg="for profile reload")
 
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")

--- a/tools/ha_sim_test/recipes/r25_phase_3c_fix_mismatch_notification_dismissed.py
+++ b/tools/ha_sim_test/recipes/r25_phase_3c_fix_mismatch_notification_dismissed.py
@@ -84,7 +84,7 @@ class R25Phase3cFixMismatchNotificationDismissed(Recipe):
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         # Check 1: FAN remote entity should NOT have class_mismatch attribute
         entities_fixed = get_entities(ctx.token)

--- a/tools/ha_sim_test/recipes/r26_phase_3c_missing__class_detection.py
+++ b/tools/ha_sim_test/recipes/r26_phase_3c_missing__class_detection.py
@@ -61,7 +61,7 @@ class R26Phase3cMissingClassDetection(Recipe):
             )
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
 
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")

--- a/tools/ha_sim_test/recipes/r28_foreign_hgi_0004_zone_names_not_blocked_by_block_l.py
+++ b/tools/ha_sim_test/recipes/r28_foreign_hgi_0004_zone_names_not_blocked_by_block_l.py
@@ -100,7 +100,7 @@ class R28ForeignHgi0004ZoneNamesNotBlockedByBlockL(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
@@ -157,7 +157,7 @@ class R28ForeignHgi0004ZoneNamesNotBlockedByBlockL(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(5, "for scan engine to process")
+        ctx.wait(5, "for scan engine to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r28_foreign_hgi_0004_zone_names_not_blocked_by_block_l.py
+++ b/tools/ha_sim_test/recipes/r28_foreign_hgi_0004_zone_names_not_blocked_by_block_l.py
@@ -105,12 +105,12 @@ class R28ForeignHgi0004ZoneNamesNotBlockedByBlockL(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r28 = get_schema_retry()
         ctl_zones_r28 = schema_r28.get(CTL, {}).get("zones", {})
@@ -162,12 +162,12 @@ class R28ForeignHgi0004ZoneNamesNotBlockedByBlockL(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError:
             pass
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         # The foreign HGI should appear in the schema (it was already there
         # from the profile, but the 30C9 should not cause a FILTER EXCEPTION)

--- a/tools/ha_sim_test/recipes/r28_foreign_hgi_0004_zone_names_not_blocked_by_block_l.py
+++ b/tools/ha_sim_test/recipes/r28_foreign_hgi_0004_zone_names_not_blocked_by_block_l.py
@@ -64,7 +64,7 @@ class R28ForeignHgi0004ZoneNamesNotBlockedByBlockL(Recipe):
             print("  Profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Verify the foreign HGI is in the schema
         schema_r28_init = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
+++ b/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
@@ -24,7 +24,6 @@ from ..helpers import (
     get_ramses_storage,
     get_schema,
     get_schema_retry,
-    is_ha_ready,
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
@@ -59,7 +58,7 @@ class R29BdrBroadcasting3b003ef0ApplianceControlIssue(Recipe):
         # hold the appliance_control/hotwater_valve slots.
         print("  Stopping ha-sim and clearing cached state...")
         clear_cached_state(ctx.log_monitor, label="R29 pre-restart")
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")

--- a/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
+++ b/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
@@ -164,7 +164,7 @@ class R29BdrBroadcasting3b003ef0ApplianceControlIssue(Recipe):
         # the sim test to avoid the hotwater_valve slot collision (both non-FC
         # BDRs would compete for the single hotwater_valve slot).
 
-        ctx.wait(3, "for scan engine to process")
+        ctx.wait(3, "for scan engine to process", floor=2.0)
 
         # Accept the two BDRs so they enter the known_list
         print("  Accepting discovered BDRs...")

--- a/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
+++ b/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
@@ -80,7 +80,7 @@ class R29BdrBroadcasting3b003ef0ApplianceControlIssue(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate CTL for heartbeats
         try:

--- a/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
+++ b/tools/ha_sim_test/recipes/r29_bdr_broadcasting_3b003ef0_appliance_control_issue_.py
@@ -61,7 +61,7 @@ class R29BdrBroadcasting3b003ef0ApplianceControlIssue(Recipe):
         ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
 
         # Load mixed profile (has CTL 01:150000 as main_tcs for TCS placement)
         print("  Loading mixed profile (has CTL for TCS placement)...")
@@ -187,12 +187,12 @@ class R29BdrBroadcasting3b003ef0ApplianceControlIssue(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         schema_r29 = get_schema_retry()
         ctl_r29 = schema_r29.get(CTL, {})

--- a/tools/ha_sim_test/recipes/r30_phase_3d4_multirem_fan_with__bound_as_liststr.py
+++ b/tools/ha_sim_test/recipes/r30_phase_3d4_multirem_fan_with__bound_as_liststr.py
@@ -79,7 +79,7 @@ class R30Phase3d4MultiremFanWithBoundAsListstr(Recipe):
             print("  Profile loaded with list-valued _bound")
         except RuntimeError as e:
             print(f"  Profile load failed: {str(e)[:80]}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate FAN + both REMs for heartbeats
         for dev_id, name in [(FAN, "FAN"), (REM, "REM"), (rem2, "REM2")]:

--- a/tools/ha_sim_test/recipes/r30_phase_3d4_multirem_fan_with__bound_as_liststr.py
+++ b/tools/ha_sim_test/recipes/r30_phase_3d4_multirem_fan_with__bound_as_liststr.py
@@ -102,12 +102,12 @@ class R30Phase3d4MultiremFanWithBoundAsListstr(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(10, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=15, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         # Check 1: FAN's known_list entry has bound as a list
         # NOTE: get_known_list() reads the config entry's USER known_list, not

--- a/tools/ha_sim_test/recipes/r31_phase_3d6__commands_override_precedence_e2e.py
+++ b/tools/ha_sim_test/recipes/r31_phase_3d6__commands_override_precedence_e2e.py
@@ -104,12 +104,12 @@ class R31Phase3d6CommandsOverridePrecedenceE2e(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(10, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=15, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         # Check 1: FAN schema has _commands with dict template for "low"
         schema_after_r31 = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r31_phase_3d6__commands_override_precedence_e2e.py
+++ b/tools/ha_sim_test/recipes/r31_phase_3d6__commands_override_precedence_e2e.py
@@ -81,7 +81,7 @@ class R31Phase3d6CommandsOverridePrecedenceE2e(Recipe):
             print("  Profile loaded with _commands dict template")
         except RuntimeError as e:
             print(f"  Profile load failed: {str(e)[:80]}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate FAN + REM for heartbeats
         for dev_id, name in [(FAN, "FAN"), (REM, "REM"), (CO2, "CO2")]:

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -222,6 +222,7 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
             timeout=10,
             interval=1,
             msg="for battery entity to reflect restored 1060",
+            floor=5.0,
         )
         entities_r32_after = get_entities(ctx.token)
         bat_after = find_battery_entity(entities_r32_after, TRV)

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -112,7 +112,7 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for entity state write")
+        ctx.wait(5, "for entity state write", floor=3.0)
 
         # 3. Verify the TRV battery binary sensor has a state before restart
         entities_r32 = get_entities(ctx.token)

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -204,6 +204,25 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
         #      no 1060 → battery entity = Unknown/None.
         #    WITH FIX (1060 removed from HIGH_VOLUME_STATUS_CODES): the aged
         #      1060 is restored → battery entity retains its state.
+        #    The restored packet may need a force_update + entity state write
+        #    cycle before the binary sensor reflects the restored state.
+        try:
+            call_service(ctx.token, "ramses_cc", "force_update")
+        except RuntimeError:
+            pass
+        ctx.wait(5, "for entity state write after restore", floor=3.0)
+
+        def _battery_has_state() -> bool:
+            entities = get_entities(ctx.token)
+            bat = find_battery_entity(entities, TRV)
+            return bat is not None and bat.get("state") in ("on", "off")
+
+        ctx.wait_for(
+            _battery_has_state,
+            timeout=10,
+            interval=1,
+            msg="for battery entity to reflect restored 1060",
+        )
         entities_r32_after = get_entities(ctx.token)
         bat_after = find_battery_entity(entities_r32_after, TRV)
         bat_state_after = bat_after.get("state") if bat_after else None

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -107,7 +107,7 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
             print("    1060 I injected")
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(5, "for 1060 to process")
+        ctx.wait(5, "for 1060 to process", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -71,7 +71,7 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         for dev_id, name in [(CTL, "CTL"), (TRV, "TRV"), (DHW, "DHW")]:
             try:

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -24,10 +24,10 @@ from ..helpers import (
     get_ramses_storage,
     get_schema,
     get_schema_retry,
-    is_ha_ready,
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
+    wait_for_ha_ready,
     write_ramses_storage,
     ws_send,
 )
@@ -190,7 +190,7 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
         subprocess.run(
             ["docker", "start", get_current_instance().name], capture_output=True
         )
-        wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         wait_for(

--- a/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
+++ b/tools/ha_sim_test/recipes/r32_battery_1060_cache_restore_stale_1060_must_survive.py
@@ -28,6 +28,7 @@ from ..helpers import (
     load_profile_yaml,
     wait_for,
     wait_for_ha_ready,
+    wait_for_ramses_cc_loaded,
     write_ramses_storage,
     ws_send,
 )
@@ -193,10 +194,8 @@ class R32Battery1060CacheRestoreStale1060MustSurvive(Recipe):
         wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        wait_for(
-            is_ramses_cc_loaded,
-            timeout=15,
-            msg="for ramses_cc to restore cached packets",
+        wait_for_ramses_cc_loaded(
+            timeout=15, msg="for ramses_cc to restore cached packets"
         )
 
         # 5. Check the battery binary sensor state after restart.

--- a/tools/ha_sim_test/recipes/r33_phase_3d3b_consolidated_stripper_validation_ma.py
+++ b/tools/ha_sim_test/recipes/r33_phase_3d3b_consolidated_stripper_validation_ma.py
@@ -142,12 +142,12 @@ class R33Phase3d3bConsolidatedStripperValidationMa(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(10, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=15, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         # Check 1: Schema survived the round-trip (gateway accepted it)
         schema_after_r33 = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r33_phase_3d3b_consolidated_stripper_validation_ma.py
+++ b/tools/ha_sim_test/recipes/r33_phase_3d3b_consolidated_stripper_validation_ma.py
@@ -119,7 +119,7 @@ class R33Phase3d3bConsolidatedStripperValidationMa(Recipe):
             )
             return  # can't continue if profile load failed
 
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate CTL + FAN + REM for heartbeats
         for dev_id, name in [(CTL, "CTL"), (FAN, "FAN"), (REM, "REM")]:

--- a/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
@@ -14,7 +14,6 @@ from ..helpers import (
     clear_cached_state,
     get_current_instance,
     get_schema_retry,
-    is_ha_ready,
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
@@ -71,7 +70,7 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
         # a truly clean state for this race condition test.
         print("  Stopping ha-sim and clearing cached state...")
         clear_cached_state(ctx.log_monitor, label="R34 pre-restart")
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")

--- a/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
@@ -17,6 +17,7 @@ from ..helpers import (
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
+    wait_for_schema_populated,
     ws_send,
 )
 from ..profile import MIXED_KL, MIXED_SCHEMA, get_mixed_kl
@@ -128,11 +129,7 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
             )
         except RuntimeError:
             pass
-        ctx.wait_for(
-            lambda: len(get_schema_retry(max_tries=1)) > 5,
-            timeout=15,
-            msg="for CTL heartbeats + schema population",
-        )
+        wait_for_schema_populated(timeout=15)
 
         # --- Step 1: Inject 000C RP with HTG role (0E) ---
         # This binds the BDR as hotwater_valve (domain FA) to a DhwZone.

--- a/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
@@ -73,7 +73,7 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
         ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
 
         # --- Build a custom profile without DHW sensor ---
         # The mixed profile has stored_hotwater: {sensor: DHW}.  We remove
@@ -163,12 +163,12 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(10, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=15, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_step1 = get_schema_retry()
         ctl_step1 = schema_step1.get(CTL, {})
@@ -230,12 +230,12 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(10, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=15, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_step2 = get_schema_retry()
         ctl_step2 = schema_step2.get(CTL, {})

--- a/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
@@ -158,7 +158,7 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(5, "for 000C HTG processing")
+        ctx.wait(5, "for 000C HTG processing", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
@@ -225,7 +225,7 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(5, "for 000C APP processing")
+        ctx.wait(5, "for 000C APP processing", floor=2.0)
         try:
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:

--- a/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r34_bdr_reparent_hotwater_valve_to_appliance_control_issue_834.py
@@ -114,7 +114,7 @@ class R34BdrReparentHotwaterValveToApplianceControlIssue834(Recipe):
             print("  Profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        ctx.wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
 
         # Activate CTL for heartbeats

--- a/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
@@ -113,7 +113,7 @@ class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
             print("    1260 I injected")
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(3, "for 1260 to process", floor=2.0)
+        ctx.wait(5, "for 1260 to process", floor=4.0)
 
         # 3. Inject 10A0 RP from CTL (01:150000) — DHW params/setpoint
         #    Payload: 00 + setpoint(50.0°C=0x1388) + overrun(00) + diff(10.0°C=0x03E8)

--- a/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
@@ -164,7 +164,7 @@ class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for entity state write")
+        ctx.wait(5, "for entity state write", floor=3.0)
 
         # 5. Find the water_heater entity for the DhwZone
         #    The DhwZone ID is CTL + "_HW" (e.g. "01:150000_HW"), but the

--- a/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
@@ -55,7 +55,7 @@ class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate CTL and DHW for heartbeats
         for dev_id, name in [(CTL, "CTL"), (DHW, "DHW")]:

--- a/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r35_water_heater_dhw_cqrs_hydration_issue_843.py
@@ -113,7 +113,7 @@ class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
             print("    1260 I injected")
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(3, "for 1260 to process")
+        ctx.wait(3, "for 1260 to process", floor=2.0)
 
         # 3. Inject 10A0 RP from CTL (01:150000) — DHW params/setpoint
         #    Payload: 00 + setpoint(50.0°C=0x1388) + overrun(00) + diff(10.0°C=0x03E8)
@@ -136,7 +136,7 @@ class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
             print("    10A0 I injected")
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(3, "for 10A0 to process")
+        ctx.wait(3, "for 10A0 to process", floor=2.0)
 
         # 4. Inject 1F41 I from CTL (01:150000) — DHW mode
         #    Payload: 00 + active(00=False) + mode(00=follow_schedule) + FFFFFF
@@ -157,7 +157,7 @@ class R35WaterHeaterDhwCqrsHydrationIssue843(Recipe):
             print("    1F41 I injected")
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(5, "for 1F41 to process")
+        ctx.wait(5, "for 1F41 to process", floor=2.0)
 
         # Force entity state update
         try:

--- a/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
@@ -132,7 +132,7 @@ class R36ZoneClimateStateHydrationIssue843(Recipe):
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for entity state write")
+        ctx.wait(5, "for entity state write", floor=3.0)
 
         # 4. Find the climate entity for zone 03
         #    ramses_cc creates climate entities for each zone.  The entity_id

--- a/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
@@ -125,7 +125,7 @@ class R36ZoneClimateStateHydrationIssue843(Recipe):
             print("    2349 I injected")
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
-        ctx.wait(5, "for 2349 to process")
+        ctx.wait(5, "for 2349 to process", floor=4.0)
 
         # Force entity state update
         try:

--- a/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
@@ -55,7 +55,7 @@ class R36ZoneClimateStateHydrationIssue843(Recipe):
             print("  mixed profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # Activate CTL for heartbeats
         try:

--- a/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
@@ -44,7 +44,6 @@ from ..helpers import (
     call_service,
     clear_cached_state,
     get_schema_retry,
-    is_ha_ready,
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
@@ -90,7 +89,7 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
         # old 000C packets.  We need a truly clean slate.
         print("  Stopping ha-sim and clearing cached state...")
         clear_cached_state(ctx.log_monitor, label="R37 pre-restart")
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")

--- a/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
@@ -139,7 +139,7 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
             print("  Profile loaded")
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        ctx.wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
 
         # Activate CTL for heartbeats

--- a/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
@@ -245,7 +245,7 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
         except RuntimeError as e:
             print(f"    Inject failed: {str(e)[:80]}")
 
-        ctx.wait(3, "for scan engine to process")
+        ctx.wait(3, "for scan engine to process", floor=2.0)
 
         # Accept both discovered devices so they enter the known_list
         print("  Accepting discovered OTB and BDR...")

--- a/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
@@ -92,7 +92,7 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
         ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
 
         # --- Build a custom profile with OTB + BDR + DHW sensor ---
         # The schema declares:
@@ -268,12 +268,12 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
             call_service(ctx.token, "ramses_cc", "sync_topology")
         except RuntimeError as e:
             print(f"  sync_topology failed: {e}")
-        ctx.wait(5, "for sync_learned_topology")
+        ctx.wait_for_schema_stable(timeout=10, msg="for sync_learned_topology")
         try:
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save_client_state")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save_client_state")
 
         schema_r37 = get_schema_retry()
         ctl_r37 = schema_r37.get(CTL, {})
@@ -344,7 +344,7 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
             call_service(ctx.token, "ramses_cc", "force_update")
         except RuntimeError:
             pass
-        ctx.wait(5, "for save")
+        ctx.wait_for_schema_stable(timeout=10, msg="for save")
 
         schema_r37_2 = get_schema_retry()
         ctl_r37_2 = schema_r37_2.get(CTL, {})

--- a/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
+++ b/tools/ha_sim_test/recipes/r37_bdr_hotwater_valve_misclassified_as_appliance_control_issue_834.py
@@ -47,6 +47,7 @@ from ..helpers import (
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
+    wait_for_schema_populated,
     ws_send,
 )
 from ..profile import MIXED_KL, MIXED_SCHEMA, get_mixed_kl
@@ -153,11 +154,7 @@ class R37BdrHotwaterValveMisclassifiedAsApplianceControlIssue834(Recipe):
             )
         except RuntimeError:
             pass
-        ctx.wait_for(
-            lambda: len(get_schema_retry(max_tries=1)) > 5,
-            timeout=15,
-            msg="for CTL heartbeats + schema population",
-        )
+        wait_for_schema_populated(timeout=15)
 
         # --- Step 1: Both OTB and BDR broadcast 3B00 I (TPI loop) ---
         # In peternash's system, both relays broadcast 3B00/3EF0 as I.

--- a/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
+++ b/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
@@ -89,7 +89,7 @@ class R38FakedThm30c9CorrectZoneIdxIssue639(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        ctx.wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
 
         # Activate CTL for heartbeats

--- a/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
+++ b/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
@@ -54,7 +54,7 @@ class R38FakedThm30c9CorrectZoneIdxIssue639(Recipe):
         ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
 
         # 1. Load mixed profile with the zone-03 sensor (01:150003) faked
         sensor_id = "01:150003"

--- a/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
+++ b/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
@@ -163,7 +163,7 @@ class R38FakedThm30c9CorrectZoneIdxIssue639(Recipe):
                 f"(expected): {str(e)[:60]}"
             )
 
-        ctx.wait(5, "for 30C9 packet to appear in log")
+        ctx.wait(5, "for 30C9 packet to appear in log", floor=2.0)
 
         # 5. Read the HA log for the 30C9 packet from our faked device.
         #    The faked device sends a 30C9 I broadcast via MQTT.  The

--- a/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
+++ b/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
@@ -29,7 +29,6 @@ from ..helpers import (
     clear_cached_state,
     get_current_instance,
     get_entities,
-    is_ha_ready,
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
@@ -52,7 +51,7 @@ class R38FakedThm30c9CorrectZoneIdxIssue639(Recipe):
         #    queue and preventing the 30C9 I packet from being transmitted).
         print("  Stopping ha-sim and clearing cached state...")
         clear_cached_state(ctx.log_monitor, label="R38 pre-clean")
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")

--- a/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
+++ b/tools/ha_sim_test/recipes/r38_faked_thm_30c9_correct_zone_idx_issue_639.py
@@ -32,6 +32,7 @@ from ..helpers import (
     is_ramses_cc_loaded,
     load_profile_yaml,
     wait_for,
+    wait_for_schema_populated,
     ws_send,
 )
 from ..profile import MIXED_KL, MIXED_SCHEMA, get_mixed_kl, mixed_yaml
@@ -105,11 +106,7 @@ class R38FakedThm30c9CorrectZoneIdxIssue639(Recipe):
             pass
         from ..helpers import get_schema_retry
 
-        ctx.wait_for(
-            lambda: len(get_schema_retry(max_tries=1)) > 5,
-            timeout=15,
-            msg="for CTL heartbeats + schema population",
-        )
+        wait_for_schema_populated(timeout=15)
 
         # 2. Find the temperature sensor entity for 01:150003
         entities = get_entities(ctx.token)

--- a/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
+++ b/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
@@ -142,7 +142,7 @@ except Exception as e:
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         ctx.wait_for(
             is_ramses_cc_loaded,

--- a/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
+++ b/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
@@ -207,7 +207,7 @@ except Exception as e:
                 print("    30C9 I injected")
             except RuntimeError as e:
                 print(f"    Inject failed: {str(e)[:80]}")
-            ctx.wait(5, "for 30C9 to process")
+            ctx.wait(5, "for 30C9 to process", floor=2.0)
 
             # Force entity state update
             try:

--- a/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
+++ b/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
@@ -214,7 +214,7 @@ except Exception as e:
                 call_service(ctx.token, "ramses_cc", "force_update")
             except RuntimeError:
                 pass
-            ctx.wait(3, "for entity state write")
+            ctx.wait(3, "for entity state write", floor=3.0)
 
             # Check that a climate entity for zone 03 exists and has a temp
             entities = get_entities(ctx.token)

--- a/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
+++ b/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
@@ -22,6 +22,7 @@ from ..helpers import (
     get_entities,
     is_ramses_cc_loaded,
     wait_for,
+    wait_for_schema_populated,
     ws_send,
 )
 
@@ -144,11 +145,7 @@ except Exception as e:
             print(f"  Profile load failed: {e}")
         ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
-        ctx.wait_for(
-            is_ramses_cc_loaded,
-            timeout=20,
-            msg="for ramses_cc to initialize",
-        )
+        ctx.wait_for_ramses_cc_loaded(timeout=20, msg="for ramses_cc to initialize")
 
         # Activate CTL
         try:
@@ -166,11 +163,7 @@ except Exception as e:
         # the preloaded schema and created entities)
         from ..helpers import get_schema_retry
 
-        ctx.wait_for(
-            lambda: len(get_schema_retry(max_tries=1)) > 5,
-            timeout=20,
-            msg="for CTL heartbeats + schema population",
-        )
+        wait_for_schema_populated(timeout=20)
 
         # Inject a 30C9 I packet from the CTL (01:150000) for zone 03
         #    payload: 03 + hex_for_temp(22.0)

--- a/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
+++ b/tools/ha_sim_test/recipes/r40_packetdto_rx_path_integrity_issue_639.py
@@ -59,6 +59,9 @@ except ImportError as e:
         field_names = set(result["fields"])
 
         # Allowed L1/L2 fields per issue 639
+        # is_tx was added to distinguish inbound (RX) vs outbound (TX)
+        # packets as part of the OSI layer decoupling — it is a legitimate
+        # L1/L2 transport field, not an application-layer field.
         allowed_fields = {
             "timestamp",
             "rssi",
@@ -70,6 +73,7 @@ except ImportError as e:
             "code",
             "length",
             "payload",
+            "is_tx",
         }
 
         ctx.check(

--- a/tools/ha_sim_test/recipes/r41_hvac_topology_roundtrip_load_fan_issue_767.py
+++ b/tools/ha_sim_test/recipes/r41_hvac_topology_roundtrip_load_fan_issue_767.py
@@ -78,7 +78,7 @@ except ImportError as e:
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Verify the config entry schema has HVAC structure
         schema = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r42_hvac_topology_binding_rules_issue_767.py
+++ b/tools/ha_sim_test/recipes/r42_hvac_topology_binding_rules_issue_767.py
@@ -85,7 +85,7 @@ except (ImportError, AttributeError) as e:
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Inject 31D9 I from FAN (32:150000) — FAN announces itself
         print(f"  Injecting 31D9 I from FAN {FAN}...")

--- a/tools/ha_sim_test/recipes/r43_co2_dual_role_device_issue_767.py
+++ b/tools/ha_sim_test/recipes/r43_co2_dual_role_device_issue_767.py
@@ -89,7 +89,7 @@ except ImportError as e:
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         dual_role_id = "37:153002"
 

--- a/tools/ha_sim_test/recipes/r44_schema_migration_traits_survive_restart_issue_767.py
+++ b/tools/ha_sim_test/recipes/r44_schema_migration_traits_survive_restart_issue_767.py
@@ -54,7 +54,7 @@ class R44SchemaMigrationTraitsSurviveRestartIssue767(Recipe):
             )
         except (RuntimeError, OSError) as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Verify schema has _alias trait
         schema = get_schema_retry()
@@ -90,7 +90,7 @@ class R44SchemaMigrationTraitsSurviveRestartIssue767(Recipe):
             )
         except RuntimeError:
             pass
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 4. Verify traits survived the restart
         schema_after = get_schema_retry()

--- a/tools/ha_sim_test/recipes/r45_crash_recovery_topology_survives_via_cache_issue_767.py
+++ b/tools/ha_sim_test/recipes/r45_crash_recovery_topology_survives_via_cache_issue_767.py
@@ -45,7 +45,7 @@ class R45CrashRecoveryTopologySurvivesViaCacheIssue767(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Activate CTL for heartbeats
         try:
@@ -114,7 +114,7 @@ class R45CrashRecoveryTopologySurvivesViaCacheIssue767(Recipe):
             )
         except RuntimeError:
             pass
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 5. Verify entities reappear from cached schema
         entities_after = get_entities(ctx.token)

--- a/tools/ha_sim_test/recipes/r46_disabled_trait_device_excluded_issue_767.py
+++ b/tools/ha_sim_test/recipes/r46_disabled_trait_device_excluded_issue_767.py
@@ -45,7 +45,7 @@ class R46DisabledTraitDeviceExcludedIssue767(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Verify TRV exists before disabling
         entities = get_entities(ctx.token)
@@ -77,7 +77,7 @@ class R46DisabledTraitDeviceExcludedIssue767(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 4. Verify the TRV entity is gone or unavailable
         entities_after = get_entities(ctx.token)
@@ -134,7 +134,7 @@ class R46DisabledTraitDeviceExcludedIssue767(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 8. Verify TRV entity reappears
         entities_final = get_entities(ctx.token)

--- a/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
+++ b/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
@@ -51,7 +51,7 @@ class R47EavesdropFalseUnknownDevicesTrackedIssue767(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Inject a packet from an unknown device
         #    04:999999 is not in any known_list or schema

--- a/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
+++ b/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
@@ -23,7 +23,6 @@ from ..helpers import (
     grep_ha_log,
     is_ramses_cc_loaded,
     wait_for,
-    wait_for_transport_ready,
     ws_send,
 )
 
@@ -54,11 +53,16 @@ class R47EavesdropFalseUnknownDevicesTrackedIssue767(Recipe):
             print(f"  Profile load failed: {e}")
         ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
-        # Wait for the MQTT transport to reconnect — the fresh_start reload
-        # closes the transport and injected packets are silently dropped
-        # ("Transport Error: Transport is closing or has closed") until it
-        # reconnects (~15-20s).
-        wait_for_transport_ready(timeout=30)
+        # KNOWN BUG: the fresh_start profile reload closes the MQTT transport,
+        # but the new transport's _closing flag stays True even after
+        # "Subscribed to status topic" and "device came back online" are
+        # logged.  Injected packets are silently dropped with
+        # "Transport Error: Transport is closing or has closed" and never
+        # reach the DiscoveryScan.  This is a ramses_rf transport lifecycle
+        # bug — the old transport instance is not properly cleaned up during
+        # the reload and its _closing state leaks into the new instance.
+        # See: https://github.com/ramses-rf/ramses_cc/issues/767
+        ctx.wait(10, "for transport to stabilise after reload")
         # 2. Inject a packet from an unknown device
         #    04:999999 is not in any known_list or schema
         unknown_device = "04:999999"

--- a/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
+++ b/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
@@ -107,13 +107,13 @@ class R47EavesdropFalseUnknownDevicesTrackedIssue767(Recipe):
                 "get_discovered_devices",
                 {},
             )
-            ctx.wait(2, "for event to fire")
+            ctx.wait(3, "for event to fire + log flush", floor=3.0)
 
             # Check the HA log for the service's log output
             svc_log = grep_ha_log(
                 f"get_discovered_devices.*{unknown_device.replace(':', '.')}"
                 f"|{unknown_device.replace(':', '.')}.*type=.*confidence=.*status=",
-                since_lines=200,
+                since_lines=500,
             )
             ctx.check(
                 f"unknown device {unknown_device} in get_discovered_devices "

--- a/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
+++ b/tools/ha_sim_test/recipes/r47_eavesdrop_false_unknown_devices_tracked_issue_767.py
@@ -23,6 +23,7 @@ from ..helpers import (
     grep_ha_log,
     is_ramses_cc_loaded,
     wait_for,
+    wait_for_transport_ready,
     ws_send,
 )
 
@@ -53,6 +54,11 @@ class R47EavesdropFalseUnknownDevicesTrackedIssue767(Recipe):
             print(f"  Profile load failed: {e}")
         ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
+        # Wait for the MQTT transport to reconnect — the fresh_start reload
+        # closes the transport and injected packets are silently dropped
+        # ("Transport Error: Transport is closing or has closed") until it
+        # reconnects (~15-20s).
+        wait_for_transport_ready(timeout=30)
         # 2. Inject a packet from an unknown device
         #    04:999999 is not in any known_list or schema
         unknown_device = "04:999999"

--- a/tools/ha_sim_test/recipes/r50_device_health_tracking_issue_767.py
+++ b/tools/ha_sim_test/recipes/r50_device_health_tracking_issue_767.py
@@ -111,7 +111,7 @@ class R50DeviceHealthTrackingIssue767(Recipe):
             )
         except RuntimeError as e:
             print(f"  Profile load failed: {e}")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         # 2. Verify schema loaded
         schema = get_schema_retry()
@@ -318,7 +318,7 @@ except Exception as e:
         ctx.wait(30, "for HA container to restart")
         ctx.refresh_token()
         ctx.wait(10, "for ramses_cc to initialize")
-        wait_for(is_ramses_cc_loaded, timeout=20, msg="for ramses_cc reload")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
         ctx.wait(5, "for discovery manager to initialize")
 

--- a/tools/ha_sim_test/recipes/r59_phase4_cleanup_stale_known_list.py
+++ b/tools/ha_sim_test/recipes/r59_phase4_cleanup_stale_known_list.py
@@ -27,7 +27,7 @@ import subprocess
 
 from ..base import Recipe, RecipeContext
 from ..const import CTL
-from ..helpers import get_current_instance, get_schema_retry, is_ha_ready, wait_for
+from ..helpers import get_current_instance, get_schema_retry, wait_for_ha_ready
 
 
 class R59Phase4CleanupStaleKnownList(Recipe):
@@ -127,7 +127,7 @@ class R59Phase4CleanupStaleKnownList(Recipe):
             subprocess.run(
                 ["docker", "start", get_current_instance().name], capture_output=True
             )
-            wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+            wait_for_ha_ready(timeout=30)
             return
 
         # Step 4: Start ha-sim — async_setup_entry will run and call
@@ -136,7 +136,7 @@ class R59Phase4CleanupStaleKnownList(Recipe):
         subprocess.run(
             ["docker", "start", get_current_instance().name], capture_output=True
         )
-        wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait(10, "for ramses_cc to initialize + run cleanup")

--- a/tools/ha_sim_test/recipes/r60_send_packet_cmddto_filter_issue_864.py
+++ b/tools/ha_sim_test/recipes/r60_send_packet_cmddto_filter_issue_864.py
@@ -74,7 +74,7 @@ class R60SendPacketCmdtoFilterIssue864(Recipe):
         ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
 
         # ── Step 1: Inject a faked device into the schema ───────────
         # Phase 4: the schema is the sole source of truth.  Faked devices
@@ -184,7 +184,7 @@ class R60SendPacketCmdtoFilterIssue864(Recipe):
         ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)
         ctx.wait(5, "for protocol/filter to stabilise")
 
         # ── Step 3: Test send_packet with the faked device ───────────
@@ -382,4 +382,4 @@ except Exception as e:
         subprocess.run(["docker", "start", inst.name], capture_output=True)
         ctx.wait_for_ha_ready(timeout=30)
         ctx.refresh_token()
-        ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
+        ctx.wait_for_ramses_cc_loaded(timeout=30)

--- a/tools/ha_sim_test/recipes/r60_send_packet_cmddto_filter_issue_864.py
+++ b/tools/ha_sim_test/recipes/r60_send_packet_cmddto_filter_issue_864.py
@@ -52,7 +52,6 @@ from ..helpers import (
     clear_cached_state,
     docker_exec_python,
     get_current_instance,
-    is_ha_ready,
     is_ramses_cc_loaded,
     wait_for,
 )
@@ -72,7 +71,7 @@ class R60SendPacketCmdtoFilterIssue864(Recipe):
         # ── Setup: clean slate ──────────────────────────────────────
         print("  Stopping ha-sim and clearing cached state...")
         clear_cached_state(ctx.log_monitor, label="R60 pre-clean")
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
@@ -104,13 +103,13 @@ class R60SendPacketCmdtoFilterIssue864(Recipe):
                 f"could not read {host_path}: {e}",
             )
             subprocess.run(["docker", "start", inst.name], capture_output=True)
-            ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+            ctx.wait_for_ha_ready(timeout=30)
             return
 
         ctx.check("core.config_entries readable", bool(raw), "")
         if not raw:
             subprocess.run(["docker", "start", inst.name], capture_output=True)
-            ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+            ctx.wait_for_ha_ready(timeout=30)
             return
 
         data = json.loads(raw)
@@ -125,7 +124,7 @@ class R60SendPacketCmdtoFilterIssue864(Recipe):
         ctx.check("ramses_cc config entry found", cc_entry is not None, "")
         if cc_entry is None:
             subprocess.run(["docker", "start", inst.name], capture_output=True)
-            ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+            ctx.wait_for_ha_ready(timeout=30)
             return
 
         # Modify the config entry options (Phase 4: schema-centric):
@@ -176,13 +175,13 @@ class R60SendPacketCmdtoFilterIssue864(Recipe):
         )
         if cp_result.returncode != 0:
             subprocess.run(["docker", "start", inst.name], capture_output=True)
-            ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+            ctx.wait_for_ha_ready(timeout=30)
             return
 
         # ── Step 2: Start ha-sim and wait for ramses_cc ──────────────
         print("  Starting ha-sim with faked device in schema...")
         subprocess.run(["docker", "start", inst.name], capture_output=True)
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.log_monitor.reset_baseline()
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")
@@ -381,6 +380,6 @@ except Exception as e:
             pass
 
         subprocess.run(["docker", "start", inst.name], capture_output=True)
-        ctx.wait_for(is_ha_ready, timeout=30, msg="for ha-sim to start up")
+        ctx.wait_for_ha_ready(timeout=30)
         ctx.refresh_token()
         ctx.wait_for(is_ramses_cc_loaded, timeout=30, msg="for ramses_cc to initialize")


### PR DESCRIPTION
## Summary

Parallel test runner improvements for better visibility and faster local iteration:

- **LiveDashboard** (`tools/ha_sim_test/dashboard.py`): renders a fixed-height pane per container (current recipe, pass/fail tally, elapsed time, recent output lines) that refreshes in place via ANSI cursor movement. Output is attributed to the correct container via the existing contextvars-based `get_current_instance()` mechanism, not by parsing `[name]` text prefixes. Auto-disables when stdout isn't a TTY so log-capture workflows are unaffected.
- **`WAIT_SCALE` env knob** (`helpers.py`): `HA_SIM_TEST_WAIT_SCALE` multiplies every fixed `wait()`/`ctx.wait()` sleep and every `wait_for()` timeout/interval. Defaults to 1.0 (no change). Useful for binary-searching the minimum safe scale factor across the suite. `ctx.wait()` in `base.py` now delegates to `helpers.wait()` so it inherits scaling automatically.
- **`ws_send` retry**: retries transient timeouts/connection errors up to 2 times with 3s backoff (common under parallel container contention). Does not retry on `unknown_command` or genuine WS error responses.
- **`wait_for_transport_ready` helper**: polls HA logs for the MQTT transport "Subscribed to status topic" message after a profile reload, replacing blind fixed sleeps that were either too short (packet injection failed) or too long (wasted time).
- **Fix `MqttEndpoint`** in device_simulator to pass `gateway_id=SIMULATOR_HGI_ID` — without this the endpoint used the default gateway_id (`18:001234`) which mismatched the simulator's own packets, causing transport errors in R19/R47/R11 under parallel load.
- **R19**: use `reload_ramses_cc=False` for the mixed-profile reload to avoid destabilising the MQTT transport on warm-started containers.
- **R40**: add `is_tx` to `PacketDTO` allowed fields (legitimate L1/L2 transport field added during OSI layer decoupling, issue 639).
- **`docs/notepad.txt`**: document the 8 remaining pre-existing parallel-suite failures with root-cause hints and investigation order.

#### Test plan

- [x] `ruff check` + `ruff format` pass on all touched files
- [x] `mypy` introduces no new errors (18 pre-existing, unchanged)
- [x] Pre-commit hooks all pass
- [x] 4-container parallel suite runs with dashboard rendering correctly per pane
- [x] Dashboard auto-disables (0 ANSI codes) when piped to a file
- [x] `HA_SIM_TEST_WAIT_SCALE=0.5` runs without crashes
- [x] R22/R20 passing, total parallel failures reduced from 17 to 8 (remaining 8 are pre-existing, documented in notepad.txt)