### PR TITLE
fix: update R30/R36/R48 ha_sim_test recipes for 919/843 fixes

### DIFF
--- a/tools/ha_sim_test/recipes/r30_phase_3d4_multirem_fan_with__bound_as_liststr.py
+++ b/tools/ha_sim_test/recipes/r30_phase_3d4_multirem_fan_with__bound_as_liststr.py
@@ -163,8 +163,10 @@ class R30Phase3d4MultiremFanWithBoundAsListstr(Recipe):
         )
 
         # Check 6: no validation errors about _bound trait specifically.
-        # We grep for "_bound" (with underscore) to avoid matching unrelated
-        # errors that happen to contain "bound" in a different context.
+        # We look for ERROR lines that mention _bound in a validation/schema
+        # context, not in state_changed payloads (which contain _bound as a
+        # normal entity attribute key and can appear in websocket backpressure
+        # errors under parallel load).
         raw_log_r30 = subprocess.run(
             [
                 "docker",
@@ -180,7 +182,15 @@ class R30Phase3d4MultiremFanWithBoundAsListstr(Recipe):
         bound_errors = [
             line
             for line in raw_log_r30.splitlines()
-            if "ERROR" in line and "_bound" in line and "bound_to" not in line
+            if "ERROR" in line
+            and "_bound" in line
+            and "bound_to" not in line
+            # Exclude websocket backpressure errors (state_changed payloads
+            # contain _bound as a normal attribute, not a validation error)
+            and "websocket_api" not in line
+            and "pending messages" not in line
+            # Exclude state_changed event payloads
+            and "state_changed" not in line
         ]
         ctx.check(
             "No ERROR logs about _bound trait (list-valued _bound accepted)",

--- a/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
+++ b/tools/ha_sim_test/recipes/r36_zone_climate_state_hydration_issue_843.py
@@ -90,6 +90,25 @@ class R36ZoneClimateStateHydrationIssue843(Recipe):
             print(f"    Silence failed (continuing): {str(e)[:80]}")
         ctx.wait(2, "for emitter cancellation to take effect")
 
+        # 1c. Disable auto-answer to prevent the simulator from responding to
+        #     ramses_cc's RQ 2349 (sent by climate.async_added_to_hass) with
+        #     an RP containing a default setpoint that overwrites our inject.
+        #     The dynamic response for 2349 returns ~20.3°C for zone 03, but
+        #     we inject 21.0°C.  Re-enabled after the checks pass.
+        print("  Disabling auto-answer to prevent RP overwriting injected setpoint...")
+        try:
+            await ws_send(
+                ctx.token,
+                {
+                    "type": "ramses_extras/device_simulator/set_auto_answer",
+                    "enabled": False,
+                },
+            )
+            print("    auto-answer disabled")
+        except RuntimeError as e:
+            print(f"    Disable auto-answer failed (continuing): {str(e)[:80]}")
+        ctx.wait(1, "for auto-answer disable to take effect")
+
         # 2. Inject 2E04 I from CTL (01:150000) — system_mode = auto
         #    Payload: 00 + FFFFFFFFFFFF00 (16 hex chars, len=8)
         #    This sets the system mode to "auto" so hvac_mode doesn't
@@ -323,3 +342,15 @@ class R36ZoneClimateStateHydrationIssue843(Recipe):
             target_temp is not None and target_temp == setpoint_temp,
             f"temperature={target_temp!r} (None = bug present, issue 843)",
         )
+
+        # Re-enable auto-answer (cleanup — other recipes expect it on)
+        try:
+            await ws_send(
+                ctx.token,
+                {
+                    "type": "ramses_extras/device_simulator/set_auto_answer",
+                    "enabled": True,
+                },
+            )
+        except RuntimeError:
+            pass

--- a/tools/ha_sim_test/recipes/r48_strip_and_map_traits_pipeline_issue_767.py
+++ b/tools/ha_sim_test/recipes/r48_strip_and_map_traits_pipeline_issue_767.py
@@ -73,12 +73,19 @@ try:
         results[dev_id] = strip_and_map_traits(traits)
 
     # Check: _-prefixed keys are gone from all results
+    # Exception: _name is intentionally preserved everywhere (issue 919:
+    # ramses_rf's _TRAIT_PRESERVE_KEYS keeps _name so both device-level
+    # and zone-level names survive strip_and_map_traits for hydration)
     def find_underscore_keys(obj, path=""):
         found = []
         if isinstance(obj, dict):
             for k, v in obj.items():
                 if isinstance(k, str) and k.startswith("_"):
-                    found.append(f"{path}.{k}" if path else k)
+                    # _name is preserved by design (issue 919) — don't flag it
+                    if k == "_name":
+                        pass
+                    else:
+                        found.append(f"{path}.{k}" if path else k)
                 found.extend(find_underscore_keys(v, f"{path}.{k}" if path else k))
         elif isinstance(obj, list):
             for i, v in enumerate(obj):
@@ -110,6 +117,7 @@ try:
         "thm_has_disabled": "disabled" in thm,
         "thm_has_commands": "commands" in thm,
         "thm_has_name": "name" in thm,
+        "thm_has__name": "_name" in thm,
         "thm_has_note": "note" in thm,
         "trv_class": trv.get("class", ""),
         "trv_has_disabled": "disabled" in trv,
@@ -117,7 +125,7 @@ try:
         "ctl_has_zones": "03" in zones,
         "ctl_has_dhw": "sensor" in dhw if isinstance(dhw, dict) else False,
         "zone_03_has_name": (
-            "name" in zone_03 if isinstance(zone_03, dict) else True
+            "_name" in zone_03 if isinstance(zone_03, dict) else False
         ),
         "zone_03_has_sensor": (
             zone_03.get("sensor") == "01:150003"
@@ -196,9 +204,15 @@ except Exception as e:
         )
 
         ctx.check(
-            "_name stripped from device traits",
+            "_name not mapped to native 'name' (preserved as _name, issue 919)",
             not result.get("thm_has_name"),
-            "name key found in device traits",
+            "name key found in device traits (should not be mapped)",
+        )
+
+        ctx.check(
+            "_name preserved as _name in device traits (issue 919)",
+            result.get("thm_has__name"),
+            "_name key missing from device traits (should be preserved per 919)",
         )
 
         ctx.check(
@@ -226,7 +240,7 @@ except Exception as e:
             "commands key found in TRV",
         )
 
-        # 5. CTL topology preserved (zones, DHW) but zone _name stripped
+        # 5. CTL topology preserved (zones, DHW) with zone _name preserved (919)
         ctx.check(
             "CTL zones topology preserved",
             result.get("ctl_has_zones"),
@@ -240,9 +254,9 @@ except Exception as e:
         )
 
         ctx.check(
-            "zone _name stripped from nested zone dict",
-            not result.get("zone_03_has_name"),
-            "name key found in zone 03",
+            "zone _name preserved in nested zone dict (issue 919)",
+            result.get("zone_03_has_name"),
+            "_name key missing from zone 03 (should be preserved per issue 919)",
         )
 
         ctx.check(


### PR DESCRIPTION
## Summary
- **R48**: allow `_name` in `strip_and_map_traits` output (issue 919 preserves `_name` everywhere via `_TRAIT_PRESERVE_KEYS`, not just in zone entries)
- **R36**: disable auto-answer before injecting 2349/2309 setpoints so the simulator's RP response (with default ~20.3°C) doesn't overwrite the injected 21.0°C setpoint that the test asserts against
- **R30**: exclude websocket_api backpressure errors from the `_bound` error filter — `state_changed` payloads contain `_bound` as a normal attribute key, not a validation error

#### Test plan
- [x] R48: 21/21 pass (single-container verification)
- [x] R30: 5/5 pass (single-container verification)
- [x] R36: 3/3 pass, `target_temp=21.0` confirmed (single-container verification)
- [x] ruff + ast.parse syntax verification on all 3 recipes