### PR TITLE
test: R69 + R70 — 30C9 decoder acceptance (issues 927, 929)

### DIFF
--- a/tools/ha_sim_test/recipes/r69_faked_thm_03x_30c9_decoder_issue_929.py
+++ b/tools/ha_sim_test/recipes/r69_faked_thm_03x_30c9_decoder_issue_929.py
@@ -1,0 +1,239 @@
+"""Recipe R69: Faked 03: THM 30C9 decoder acceptance (issue 929).
+
+Regression guard for the fix in ramses_rf that ensures 30C9 packets from
+non-controller devices (03:/04:/12:) with a non-zero zone_idx are accepted
+by the decoder.
+
+Before the fix, the 0xAB guard in ``_pkt_idx`` rejected any non-zero idx
+from non-controller devices.  Faked 03: THM sensors (introduced in 0.59.2
+via commit 5b9abbe4) send 30C9 with the parent zone's idx, which triggered
+the guard and caused ``PacketPayloadInvalid: Packet idx is 0X, but expecting
+no idx (00) (0xAB)``.  The fake command failed entirely and all zones showed
+"waiting for sync".
+
+This recipe loads a profile with a 03: device configured as ``class: THM,
+faked: true``, bound to a CTL zone, calls ``put_room_temp`` on the sensor
+entity, and verifies the 30C9 packet is transmitted (not rejected by the
+decoder).
+
+See: https://github.com/ramses-rf/ramses_cc/issues/929
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from ..base import Recipe, RecipeContext
+from ..const import CTL
+from ..helpers import (
+    call_service,
+    clear_cached_state,
+    get_current_instance,
+    get_entities,
+    load_profile_yaml,
+    wait_for,
+    wait_for_schema_populated,
+    ws_send,
+)
+from ..profile import get_mixed_kl, mixed_yaml
+
+
+class R69FakedThm03x30c9DecoderIssue929(Recipe):
+    id = "R69"
+    seq = 690
+    title = "Faked 03: THM 30C9 decoder acceptance (issue 929)"
+
+    async def run(self, ctx: RecipeContext) -> None:
+        ctx.log_section("Recipe 69: Faked 03: THM 30C9 decoder acceptance (issue 929)")
+
+        # 0. Clear cached state from previous recipes.
+        print("  Stopping ha-sim and clearing cached state...")
+        clear_cached_state(ctx.log_monitor, label="R69 pre-clean")
+        ctx.wait_for_ha_ready(timeout=30)
+        ctx.log_monitor.reset_baseline()
+        ctx.refresh_token()
+        ctx.wait_for_ramses_cc_loaded(timeout=45)
+
+        # 1. Load mixed profile with a 03: device as faked THM sensor.
+        #    Use 03:155003 — a 03: (analog_thermostat) device that is NOT
+        #    a controller type, so _has_ctl is False and the 0xAB guard
+        #    would fire before the fix.
+        sensor_id = "03:155003"
+        zone_idx = "03"
+        fake_temp = 22.0
+
+        faked_kl = get_mixed_kl()
+        faked_kl[sensor_id] = {"class": "THM", "faked": True}
+
+        # Build a schema where zone 03 uses the 03: sensor
+        import yaml as _yaml
+
+        profile = _yaml.safe_load(mixed_yaml())
+        profile["known_list"] = faked_kl
+        # Override zone 03's sensor to our 03: device
+        schema = profile.get("_schema", {})
+        ctl_schema = schema.get(CTL, {})
+        zones = ctl_schema.get("zones", {})
+        if "03" in zones:
+            zones["03"]["sensor"] = sensor_id
+        profile["_schema"] = schema
+        yaml_text = _yaml.dump(profile, default_flow_style=False)
+
+        print(f"  Loading mixed profile with {sensor_id} faked (zone {zone_idx})...")
+        try:
+            await load_profile_yaml(
+                ctx.token,
+                yaml_text,
+                speed=0.01,
+                preload_schema=True,
+                reload_ramses=True,
+            )
+        except RuntimeError as e:
+            print(f"  Profile load failed: {e}")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
+        ctx.refresh_token()
+
+        # Activate CTL for heartbeats
+        try:
+            await ws_send(
+                ctx.token,
+                {
+                    "type": "ramses_extras/device_simulator/activate_profile_device",
+                    "device_id": CTL,
+                },
+            )
+        except RuntimeError:
+            pass
+        from ..helpers import get_schema_retry
+
+        wait_for_schema_populated(timeout=15)
+
+        # 2. Find the temperature sensor entity for 03:155003
+        entities = get_entities(ctx.token)
+        sensor_eid = None
+        for e in entities:
+            eid = e["entity_id"]
+            if sensor_id.replace(":", "_") in eid and eid.startswith("sensor."):
+                attrs = e.get("attributes", {})
+                if attrs.get("device_class") == "temperature":
+                    sensor_eid = eid
+                    break
+
+        ctx.check(
+            f"temperature sensor entity found for {sensor_id}",
+            sensor_eid is not None,
+            "no temperature sensor entity found",
+        )
+
+        if not sensor_eid:
+            return
+
+        print(f"  Found sensor entity: {sensor_eid}")
+
+        # 3. Call put_room_temp on the entity.
+        #    Before the fix, this would raise PacketPayloadInvalid and the
+        #    service call would fail with an HTTP 500 error mentioning
+        #    "Packet idx is 03, but expecting no idx (00) (0xAB)".
+        #    After the fix, the 30C9 packet is accepted and transmitted.
+        #    In the simulator, no echo comes back so the service may time
+        #    out, but the 30C9 packet IS transmitted and appears in the log.
+        print(
+            f"  Calling put_room_temp on {sensor_eid} "
+            f"(zone {zone_idx}, {fake_temp}C)..."
+        )
+        import time as _time
+
+        t0 = _time.time()
+        try:
+            call_service(
+                ctx.token,
+                "ramses_cc",
+                "put_room_temp",
+                {
+                    "entity_id": sensor_eid,
+                    "temperature": fake_temp,
+                },
+            )
+            print("  put_room_temp service call succeeded")
+        except RuntimeError as e:
+            elapsed = _time.time() - t0
+            err_str = str(e)
+            # The key check: the error must NOT be PacketPayloadInvalid
+            # (0xAB guard). A timeout is expected (no echo in simulator).
+            ctx.check(
+                "put_room_temp did not raise PacketPayloadInvalid (0xAB guard)",
+                "0xAB" not in err_str and "expecting no idx" not in err_str,
+                f"got 0xAB error: {err_str[:80]}",
+            )
+            print(
+                f"  put_room_temp returned error after {elapsed:.1f}s "
+                f"(expected timeout): {err_str[:60]}"
+            )
+
+        ctx.wait(5, "for 30C9 packet to appear in log", floor=2.0)
+
+        # 4. Read the HA log for the 30C9 packet from our faked 03: device.
+        def _30c9_in_log() -> bool:
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    get_current_instance().name,
+                    "bash",
+                    "-c",
+                    f"grep 'Simulator received.*{sensor_id}.*30C9' "
+                    "/config/home-assistant.log | tail -10",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            return bool(result.stdout.strip())
+
+        wait_for(
+            _30c9_in_log,
+            timeout=15,
+            interval=2,
+            msg="for 30C9 packet to appear in HA log",
+            floor=3.0,
+        )
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                get_current_instance().name,
+                "bash",
+                "-c",
+                f"grep 'Simulator received.*{sensor_id}.*30C9' "
+                "/config/home-assistant.log | tail -10",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        tx_lines: list[str] = [
+            line.strip() for line in result.stdout.splitlines() if line.strip()
+        ]
+
+        ctx.check(
+            "30C9 packet found in HA log (decoder accepted it)",
+            len(tx_lines) > 0,
+            "no 30C9 packets found — decoder likely rejected the packet (0xAB guard)",
+        )
+
+        if not tx_lines:
+            return
+
+        print(f"  Found {len(tx_lines)} 30C9 packet(s):")
+        for line in tx_lines:
+            print(f"    {line}")
+
+        # 5. Verify the payload starts with the correct zone_idx (03)
+        #    30C9 payload format: {zone_idx}{temperature_hex}
+        last_tx = tx_lines[-1]
+        parts = last_tx.split()
+        payload = parts[-1] if parts else ""
+
+        ctx.check(
+            f"30C9 payload starts with zone_idx '{zone_idx}'",
+            len(payload) >= 2 and payload[:2] == zone_idx,
+            f"payload was '{payload[:8]}' (expected idx '{zone_idx}')",
+        )


### PR DESCRIPTION
## Summary

- **R69**: New ha_sim_test recipe — regression guard for the ramses_rf decoder fix (ramses-rf/ramses_rf#1028) that accepts non-zero idx for `CODE_IDX_ARE_SIMPLE` packets (e.g. 30C9) from non-controller devices. Loads a profile with a 03: device configured as `class: THM, faked: true`, bound to a CTL zone, calls `put_room_temp` on the sensor entity, and verifies the 30C9 packet is transmitted with the correct zone_idx (not rejected by the 0xAB guard in `_pkt_idx`).
- **R70**: New ha_sim_test recipe — regression guard for the ramses_rf fix that routes sensor-sourced 30C9 to the parent zone's `temp_state`. Loads a profile with a 22: device as a zone sensor, injects a 30C9 I broadcast, and verifies the packet is accepted by the decoder with the correct temperature.

See: ramses-rf/ramses_cc#927, ramses-rf/ramses_cc#929, ramses-rf/ramses_rf#1028

#### Test plan

- [x] `prek run -a` passes (ruff, mypy, codespell)
- [x] `ha_sim_test R69` — 4/4 checks pass (sensor entity found, no 0xAB error, 30C9 in log, payload starts with zone_idx 03)
- [x] `ha_sim_test R70` — 2/2 checks pass (30C9 in log, decoded with correct temperature)
- [x] No unexpected ERROR/WARNING logs in ha-sim