### PR TITLE
feat(ha_sim_test): abort early if MQTT broker is not reachable

### DIFF
--- a/tools/ha_sim_test/mqtt_setup.py
+++ b/tools/ha_sim_test/mqtt_setup.py
@@ -14,6 +14,7 @@ does not, so we must publish them before starting tests.
 from __future__ import annotations
 
 import logging
+import socket
 from urllib.parse import urlparse
 
 import paho.mqtt.client as mqtt
@@ -21,6 +22,22 @@ import paho.mqtt.client as mqtt
 from .const import MQTT_BROKER_URL, MQTT_TOPIC_NS
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def is_mqtt_broker_ready(timeout: float = 5.0) -> bool:
+    """Check if the MQTT broker is reachable (TCP connect).
+
+    :param timeout: Socket connect timeout in seconds.
+    :return: True if the broker accepted a TCP connection.
+    """
+    parsed = urlparse(MQTT_BROKER_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 1883
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError, ConnectionRefusedError:
+        return False
 
 
 def publish_retained_online_messages(hgi_ids: list[str]) -> None:

--- a/tools/ha_sim_test/parallel.py
+++ b/tools/ha_sim_test/parallel.py
@@ -30,7 +30,7 @@ from typing import Any
 
 from .base import RecipeContext
 from .colors import bold, color_status, green, red
-from .const import InstanceConfig, make_instances
+from .const import MQTT_BROKER_URL, InstanceConfig, make_instances
 from .dashboard import LiveDashboard
 from .helpers import (
     _current_instance as _current_instance_var,
@@ -276,7 +276,11 @@ async def ensure_containers(instances: list[InstanceConfig]) -> None:
         publish_retained_online_messages(hgi_ids)
         print(f"  Published retained 'online' messages for {len(hgi_ids)} HGI(s)")
     except Exception as err:  # noqa: BLE001
-        print(f"  WARNING: could not publish retained online messages: {err}")
+        print(
+            f"  ERROR: could not publish retained online messages: {err}\n"
+            "  The MQTT broker was reachable but the publish failed. Aborting."
+        )
+        sys.exit(1)
 
     # Verify instance 1 (ha-sim) is reachable — it's not started by us
     inst1 = instances[0]
@@ -917,6 +921,22 @@ async def run_parallel(
     discover_recipes(__name__.rsplit(".", 1)[0] + ".recipes")
     print(f"  Discovered {len(REGISTRY)} recipes")
 
+    # Verify the MQTT broker is reachable — all containers depend on it
+    # for ramses_cc's MQTT transport.  Without it, every recipe will fail
+    # with cascading errors (Transport did not bind, MQTT connection
+    # failed, etc.).
+    from .mqtt_setup import is_mqtt_broker_ready
+
+    if not is_mqtt_broker_ready():
+        print(
+            f"\n  ERROR: MQTT broker at {MQTT_BROKER_URL} is not reachable.\n"
+            "  Start it with:  cd ~/docker_files/ha-sim && "
+            "docker compose -f docker-compose.mqtt.yml up -d\n"
+            "  Aborting."
+        )
+        sys.exit(1)
+    print(f"  MQTT broker at {MQTT_BROKER_URL} is reachable")
+
     # Select recipes
     if recipe_ids:
         all_recipe_ids = []
@@ -1009,7 +1029,5 @@ async def run_parallel(
     # Cleanup
     if cleanup:
         cleanup_containers(instances, remove_configs=cleanup)
-
-    import sys
 
     sys.exit(exit_code)

--- a/tools/ha_sim_test/runner.py
+++ b/tools/ha_sim_test/runner.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from .base import RecipeContext
 from .colors import bold, color_status, green, red
-from .const import InstanceConfig, make_instances
+from .const import MQTT_BROKER_URL, InstanceConfig, make_instances
 from .helpers import (
     delete_test_profiles,
     get_known_list,
@@ -88,7 +88,11 @@ async def setup(ctx: RecipeContext) -> None:
 
         publish_retained_online_messages([inst.hgi_id])
     except Exception as err:  # noqa: BLE001
-        print(f"  WARNING: could not publish retained online message: {err}")
+        print(
+            f"  ERROR: could not publish retained online message: {err}\n"
+            "  The MQTT broker was reachable but the publish failed. Aborting."
+        )
+        sys.exit(1)
 
     # Reset stale state: delete .storage/ramses_cc so ramses_cc starts fresh.
     # The profile load updates config entry options, but .storage/ramses_cc
@@ -313,6 +317,21 @@ async def run(
     # Discover all recipe modules so they self-register
     discover_recipes(__name__.rsplit(".", 1)[0] + ".recipes")
     print(f"  Discovered {len(REGISTRY)} recipes")
+
+    # Verify the MQTT broker is reachable — ramses_cc's MQTT transport
+    # cannot function without it, and all recipes will fail with
+    # cascading errors if it's down.
+    from .mqtt_setup import is_mqtt_broker_ready
+
+    if not is_mqtt_broker_ready():
+        print(
+            f"\n  ERROR: MQTT broker at {MQTT_BROKER_URL} is not reachable.\n"
+            "  Start it with:  cd ~/docker_files/ha-sim && "
+            "docker compose -f docker-compose.mqtt.yml up -d\n"
+            "  Aborting."
+        )
+        sys.exit(1)
+    print(f"  MQTT broker at {MQTT_BROKER_URL} is reachable")
 
     # Select recipes to run
     if recipe_ids:


### PR DESCRIPTION
## Summary

The MQTT broker at `localhost:1884` is a hard dependency for all ha_sim_test recipes — ramses_cc's MQTT transport cannot function without it. When the broker is down, every recipe fails with cascading errors (`Transport did not bind`, `MQTT connection failed`, etc.) that obscure the real cause.

Changes:
- Add `is_mqtt_broker_ready()` to `mqtt_setup.py` (TCP connect check)
- Call it at the start of both the sequential (`runner.py`) and parallel (`parallel.py`) runners
- If the broker is not reachable, print a helpful message with the start command and `exit(1)` immediately
- Upgrade `publish_retained_online_messages` failure from WARNING to ERROR + `exit(1)`
- Remove redundant local `import sys` in `parallel.py` that shadowed the top-level import

#### Test plan

- [x] `prek run` passes
- [x] Verified abort when broker is down: `ERROR: MQTT broker at mqtt://localhost:1884 is not reachable.`
- [x] Verified normal operation when broker is up: `MQTT broker at mqtt://localhost:1884 is reachable`