### PR TITLE
fix(ha_sim_test): resolve user home directory dynamically and expand MQTT prompt

### DIFF
--- a/tools/ha_sim_test/const.py
+++ b/tools/ha_sim_test/const.py
@@ -8,7 +8,8 @@ and propagated via a contextvar in :mod:`.helpers`.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Default HA sim instance (single-container mode, backward compatible)
@@ -18,7 +19,7 @@ HA_USER = "admin"
 HA_PASS = "admin123"
 
 # Default host path to the ha-sim config directory (bind mount source).
-HA_SIM_CONFIG_DIR = "/home/willem/docker_files/ha-sim/config"
+HA_SIM_CONFIG_DIR = str(Path.home() / "docker_files/ha-sim/config")
 
 # MQTT broker connection string (shared across instances — topic isolation
 # is via the HGI ID in the topic path).

--- a/tools/ha_sim_test/parallel.py
+++ b/tools/ha_sim_test/parallel.py
@@ -47,10 +47,12 @@ from .helpers import (
 from .log_monitor import LogMonitor
 from .mqtt_setup import publish_retained_online_messages
 from .registry import REGISTRY, discover_recipes
+from pathlib import Path
+
 from .runner import setup, teardown
 
 #: Path to ramses_cc custom_components (bind-mounted into each container).
-_RAMSES_CC_PATH = "/home/willem/dev/ramses_cc/custom_components/ramses_cc"
+_RAMSES_CC_PATH = str(Path.home() / "dev/ramses_cc/custom_components/ramses_cc")
 
 #: docker-compose template for parallel instances (2+).
 COMPOSE_TEMPLATE = """\

--- a/tools/ha_sim_test/runner.py
+++ b/tools/ha_sim_test/runner.py
@@ -326,8 +326,11 @@ async def run(
     if not is_mqtt_broker_ready():
         print(
             f"\n  ERROR: MQTT broker at {MQTT_BROKER_URL} is not reachable.\n"
-            "  Start it with:  cd ~/docker_files/ha-sim && "
-            "docker compose -f docker-compose.mqtt.yml up -d\n"
+            "  Start it via docker compose:\n"
+            "    cd ~/docker_files/ha-sim && docker compose -f docker-compose.mqtt.yml up -d\n"
+            "  Or run a standalone container:\n"
+            "    docker run -d --name ha-sim-mqtt -p 1884:1884 eclipse-mosquitto:latest "
+            "sh -c 'echo \"listener 1884 0.0.0.0\\nallow_anonymous true\" > /tmp/mosquitto.conf && mosquitto -c /tmp/mosquitto.conf'\n"
             "  Aborting."
         )
         sys.exit(1)


### PR DESCRIPTION
### The Problem:
`ha_sim_test` contained hardcoded user directory paths (`/home/willem`) in `const.py` (`HA_SIM_CONFIG_DIR`) and `parallel.py` (`_RAMSES_CC_PATH`). On developer workstations with different usernames (e.g. `/home/phil`), helper functions attempting to read/write storage on the host raised `[Errno 2] No such file or directory` error tracebacks. Additionally, when MQTT port 1884 was unreachable, the error message only suggested a `docker compose` startup command.

### The Fix:
1. **Dynamic User Home Directory Resolution:** Replaced static `/home/willem` string paths in `tools/ha_sim_test/const.py` and `tools/ha_sim_test/parallel.py` with `Path.home()` dynamic resolution (`Path.home() / "docker_files/ha-sim/config"`).
2. **Enhanced MQTT Connection Guidance:** Updated `is_mqtt_broker_ready()` error messaging in `tools/ha_sim_test/runner.py` to prompt both `docker compose` and standalone `docker run` commands when MQTT port 1884 is unreachable.

### Testing Performed:
- **Test Suite Verification:** Executed `ha_sim_test` recipes (R32, R60, R69). Verified host storage paths dynamically construct against the active user environment (`/home/phil`) without hardcoded path failures.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.