### PR TITLE
feat(ha_sim_test): save Markdown summary reports after each run

### DIFF
--- a/docs/HA_SIM_TEST_TOOL.md
+++ b/docs/HA_SIM_TEST_TOOL.md
@@ -1,7 +1,7 @@
 # ha-sim Test Tool
 
 **Location:** `tools/ha_sim_test/` (Python package)
-**Report:** `/tmp/ha_sim_test_log_report.txt`
+**Reports:** `tools/ha_sim_test/reports/` (overridable via `--reports-dir`)
 
 ## Overview
 
@@ -177,6 +177,9 @@ python3 -m ha_sim_test --wait-scale-blind 1.0 --wait-scale-poll 1.0 --wait-floor
 
 # Pipe to a log file (dashboard auto-disables, plain interleaved output)
 python3 -m ha_sim_test --parallel 4 > /tmp/run.log 2>&1
+
+# Write reports to a custom directory
+python3 -m ha_sim_test --reports-dir /tmp/ha_sim_run_20260812
 ```
 
 ### Parallel mode
@@ -293,12 +296,15 @@ visible which waits are being shortened and by how much.
 reachable, so scaling below 10s makes no sense. This is separate from
 the global `--wait-floor-poll` (the effective floor is the max of both).
 
-## Test report
+## Test reports
 
-After the run, a log report is written to:
+After each run, two reports are written to the reports directory
+(default: `tools/ha_sim_test/reports/`, overridable via `--reports-dir`):
+
+### Log report
 
 ```
-/tmp/ha_sim_test_log_report.txt
+log_report_{container}_{timestamp}.txt
 ```
 
 This report contains:
@@ -308,6 +314,24 @@ This report contains:
 - **Errors** — unexpected ERROR lines from ha-sim logs (should be 0)
 - **Warnings** — unexpected WARNING lines from ramses_cc/ramses_rf/ramses_tx (should be 0)
 - **Expected warnings (filtered out)** — the full list of known/expected patterns
+
+Up to `MAX_REPORTS_PER_CONTAINER` (5) log reports are kept per container;
+older ones are pruned automatically.
+
+### Summary report
+
+```
+summary_{container}_{timestamp}.md      # single-container mode
+summary_parallel_{timestamp}.md         # parallel mode
+```
+
+A Markdown report (readable by both humans and machines) containing:
+- **Run metadata** — timestamp, status (PASS/FAIL), totals, wall time
+- **Per-container overview** — pass/fail/time/status table (parallel mode)
+- **Per-recipe timing** — recipe, container, pass, fail, duration, title
+- **Check results** — every PASS/FAIL line with detail
+- **Container errors** — fatal errors per container (if any)
+- **Log report references** — paths to the corresponding log reports
 
 ### Log monitor design
 

--- a/tools/ha_sim_test/__main__.py
+++ b/tools/ha_sim_test/__main__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from pathlib import Path
 
 
 def main() -> None:
@@ -100,6 +101,14 @@ def main() -> None:
         "The per-call floor= parameter (e.g. wait_for_ha_ready uses floor=10) "
         "takes the max with this.",
     )
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Directory to write log and summary reports into (default: "
+        "tools/ha_sim_test/reports/).  Created if it does not exist.",
+    )
     args = parser.parse_args()
 
     # Apply CLI wait-scale/floor overrides (env vars are read at import time
@@ -114,6 +123,12 @@ def main() -> None:
         helpers.WAIT_FLOOR_BLIND = args.wait_floor_blind
     if args.wait_floor_poll is not None:
         helpers.WAIT_FLOOR_POLL = args.wait_floor_poll
+
+    # Apply reports-dir override before dispatching to runner/parallel.
+    if args.reports_dir is not None:
+        from .runner import set_reports_dir
+
+        set_reports_dir(args.reports_dir)
 
     recipe_ids = args.recipes or None
 

--- a/tools/ha_sim_test/parallel.py
+++ b/tools/ha_sim_test/parallel.py
@@ -26,6 +26,7 @@ import sys
 import time
 from contextvars import Token
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from .base import RecipeContext
@@ -47,8 +48,6 @@ from .helpers import (
 from .log_monitor import LogMonitor
 from .mqtt_setup import publish_retained_online_messages
 from .registry import REGISTRY, discover_recipes
-from pathlib import Path
-
 from .runner import setup, teardown
 
 #: Path to ramses_cc custom_components (bind-mounted into each container).
@@ -682,6 +681,7 @@ class InstanceResult:
     recipe_stats: dict[str, dict[str, Any]] = field(default_factory=dict)
     elapsed: float = 0.0
     error: str | None = None
+    log_report_path: str | None = None
 
 
 async def run_single_instance(
@@ -789,7 +789,8 @@ async def run_single_instance(
         result.recipe_stats = ctx.recipe_stats
 
         # Teardown (without sys.exit)
-        await _teardown_no_exit(ctx, start_time=start, instance=instance)
+        log_path = await _teardown_no_exit(ctx, start_time=start, instance=instance)
+        result.log_report_path = log_path
 
     except Exception as e:
         result.error = f"{type(e).__name__}: {e}"
@@ -807,8 +808,12 @@ async def _teardown_no_exit(
     *,
     start_time: float,
     instance: InstanceConfig,
-) -> None:
-    """Teardown without calling sys.exit (for parallel mode)."""
+) -> str | None:
+    """Teardown without calling sys.exit (for parallel mode).
+
+    :return: Path to the written log report, or ``None`` if no log
+        monitor was attached.
+    """
     from .helpers import delete_test_profiles
 
     try:
@@ -833,6 +838,8 @@ async def _teardown_no_exit(
             print(f"  [{instance.name}] Unexpected errors: {n_errors}")
         if n_warnings:
             print(f"  [{instance.name}] Unexpected warnings: {n_warnings}")
+        return str(report_path)
+    return None
 
 
 def merge_results(results: list[InstanceResult]) -> int:
@@ -895,6 +902,28 @@ def merge_results(results: list[InstanceResult]) -> int:
     for r in results:
         for line in r.results:
             print(f"  [{r.instance.name}] {line}")
+
+    # =====================================================================
+    # SUMMARY REPORT: Write a Markdown summary alongside the log reports
+    # =====================================================================
+    from .report_writer import RunSummary, write_summary_report
+    from .runner import REPORTS_DIR
+
+    summaries = [
+        RunSummary(
+            instance=r.instance,
+            elapsed=r.elapsed,
+            passed=r.passed,
+            failed=r.failed,
+            recipe_stats=r.recipe_stats,
+            results=r.results,
+            log_report_path=r.log_report_path,
+            error=r.error,
+        )
+        for r in results
+    ]
+    summary_path = write_summary_report(summaries, reports_dir=REPORTS_DIR)
+    print(f"\n  Summary report: {summary_path}")
 
     if total_failed > 0:
         print(f"\n  {bold(red('*** SOME TESTS FAILED ***'))}")

--- a/tools/ha_sim_test/report_writer.py
+++ b/tools/ha_sim_test/report_writer.py
@@ -1,0 +1,200 @@
+"""Markdown summary report writer for ha_sim_test runs.
+
+Writes a human- and machine-readable Markdown summary alongside the
+existing plain-text log report produced by :class:`LogMonitor`.
+
+The summary contains:
+
+- Run metadata (timestamp, container, elapsed, pass/fail counts)
+- Per-recipe timing table
+- Individual check results (PASS/FAIL lines)
+- Links to the corresponding log report file
+
+Both single-container and parallel runs use the same writer; the
+parallel runner passes a list of per-container results.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .const import InstanceConfig
+
+
+@dataclass
+class RunSummary:
+    """Collected summary data for a single test run.
+
+    Used for both single-container and parallel runs.  In parallel mode,
+    one :class:`RunSummary` is built per container and merged into a
+    combined report.
+    """
+
+    instance: InstanceConfig
+    started_wall: float = 0.0
+    elapsed: float = 0.0
+    passed: int = 0
+    failed: int = 0
+    recipe_stats: dict[str, dict[str, Any]] = field(default_factory=dict)
+    results: list[str] = field(default_factory=list)
+    log_report_path: str | None = None
+    error: str | None = None
+
+    @property
+    def total(self) -> int:
+        """Total checks (passed + failed)."""
+        return self.passed + self.failed
+
+    @property
+    def status(self) -> str:
+        """Overall status string: ``PASS``, ``FAIL``, or ``ERROR``."""
+        if self.error:
+            return "ERROR"
+        return "FAIL" if self.failed > 0 else "PASS"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from *text*."""
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def write_summary_report(
+    summaries: list[RunSummary],
+    *,
+    reports_dir: Path,
+    log_report_paths: dict[str, str] | None = None,
+) -> Path:
+    """Write a Markdown summary report for one or more containers.
+
+    :param summaries: One :class:`RunSummary` per container (single-element
+        list for single-container mode).
+    :param reports_dir: Directory to write the report into.  Created if
+        it does not exist.
+    :param log_report_paths: Optional mapping of container name to the
+        plain-text log report path, for cross-referencing.
+    :return: Path to the written Markdown report.
+    """
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+
+    # Single-container: use container name in filename.
+    # Parallel: use "parallel" prefix.
+    if len(summaries) == 1:
+        container = summaries[0].instance.name
+        filename = f"summary_{container}_{ts}.md"
+    else:
+        filename = f"summary_parallel_{ts}.md"
+
+    path = reports_dir / filename
+
+    total_passed = sum(s.passed for s in summaries)
+    total_failed = sum(s.failed for s in summaries)
+    total_elapsed = max(s.elapsed for s in summaries) if summaries else 0.0
+    overall_status = "PASS" if total_failed == 0 else "FAIL"
+
+    lines: list[str] = []
+    lines.append("# ha_sim_test Summary Report")
+    lines.append("")
+    lines.append(f"**Generated:** {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"**Status:** {overall_status}")
+    lines.append(
+        f"**Totals:** {total_passed} passed, {total_failed} failed,"
+        f" {total_passed + total_failed} total"
+    )
+    lines.append(f"**Wall time:** {total_elapsed:.1f}s ({total_elapsed / 60:.1f} min)")
+    lines.append(f"**Containers:** {len(summaries)}")
+    lines.append("")
+
+    # -- Per-container overview -------------------------------------------
+    if len(summaries) > 1:
+        lines.append("## Per-container overview")
+        lines.append("")
+        lines.append("| Container | Pass | Fail | Time (s) | Status |")
+        lines.append("|-----------|------|------|----------|--------|")
+        for s in summaries:
+            lines.append(
+                f"| {s.instance.name} | {s.passed} | {s.failed}"
+                f" | {s.elapsed:.1f} | {s.status} |"
+            )
+        lines.append("")
+
+    # -- Per-recipe timing -------------------------------------------------
+    all_stats: dict[str, dict[str, Any]] = {}
+    for s in summaries:
+        for rid, stats in s.recipe_stats.items():
+            all_stats[rid] = {**stats, "container": s.instance.name}
+
+    if all_stats:
+        lines.append("## Per-recipe timing")
+        lines.append("")
+        if len(summaries) > 1:
+            lines.append("| Recipe | Container | Pass | Fail | Time (s) | Title |")
+            lines.append("|--------|-----------|------|------|----------|-------|")
+            for rid in sorted(all_stats):
+                st = all_stats[rid]
+                lines.append(
+                    f"| {rid} | {st.get('container', '?')} "
+                    f"| {st.get('passed', 0)} | {st.get('failed', 0)}"
+                    f" | {st.get('duration', 0.0):.1f}"
+                    f" | {st.get('title', '')} |"
+                )
+        else:
+            lines.append("| Recipe | Pass | Fail | Time (s) | Title |")
+            lines.append("|--------|------|------|----------|-------|")
+            for rid in sorted(all_stats):
+                st = all_stats[rid]
+                lines.append(
+                    f"| {rid} | {st.get('passed', 0)} | {st.get('failed', 0)}"
+                    f" | {st.get('duration', 0.0):.1f}"
+                    f" | {st.get('title', '')} |"
+                )
+        lines.append("")
+
+    # -- Check results -----------------------------------------------------
+    lines.append("## Check results")
+    lines.append("")
+    for s in summaries:
+        if not s.results:
+            continue
+        if len(summaries) > 1:
+            lines.append(f"### {s.instance.name}")
+            lines.append("")
+        for line in s.results:
+            clean = _strip_ansi(line).strip()
+            lines.append(f"- {clean}")
+        lines.append("")
+
+    # -- Errors ------------------------------------------------------------
+    error_summaries = [s for s in summaries if s.error]
+    if error_summaries:
+        lines.append("## Container errors")
+        lines.append("")
+        for s in error_summaries:
+            lines.append(f"- **{s.instance.name}:** {s.error}")
+        lines.append("")
+
+    # -- Log report references ---------------------------------------------
+    log_paths = log_report_paths or {}
+    referenced = {
+        s.instance.name: s.log_report_path for s in summaries if s.log_report_path
+    }
+    # Merge explicit paths over per-summary ones
+    for name, p in log_paths.items():
+        referenced[name] = p
+
+    if referenced:
+        lines.append("## Log reports")
+        lines.append("")
+        for name in sorted(referenced):
+            p = referenced[name]
+            if p:
+                lines.append(f"- `{name}`: {p}")
+        lines.append("")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path

--- a/tools/ha_sim_test/runner.py
+++ b/tools/ha_sim_test/runner.py
@@ -42,11 +42,25 @@ from .helpers import (
 from .log_monitor import LogMonitor
 from .registry import REGISTRY, discover_recipes
 
-#: Directory for persistent test reports (keeps the last N per container).
-REPORTS_DIR = Path(__file__).parent / "reports"
+#: Default directory for persistent test reports (keeps the last N per
+#: container).  Can be overridden via :func:`set_reports_dir` (used by
+#: the ``--reports-dir`` CLI flag).
+_DEFAULT_REPORTS_DIR = Path(__file__).parent / "reports"
+
+#: Active directory for persistent test reports.
+REPORTS_DIR: Path = _DEFAULT_REPORTS_DIR
 
 #: How many report files to keep per container (older ones are pruned).
 MAX_REPORTS_PER_CONTAINER = 5
+
+
+def set_reports_dir(path: Path) -> None:
+    """Override the active reports directory.
+
+    :param path: Directory to write reports into.  Created on first use.
+    """
+    global REPORTS_DIR
+    REPORTS_DIR = path
 
 
 def _report_path(container_name: str) -> Path:
@@ -65,6 +79,28 @@ def _report_path(container_name: str) -> Path:
 
     # Prune: keep only the newest MAX_REPORTS_PER_CONTAINER per container
     pattern = f"log_report_{container_name}_*.txt"
+    existing = sorted(REPORTS_DIR.glob(pattern))
+    if len(existing) >= MAX_REPORTS_PER_CONTAINER:
+        for old in existing[: -MAX_REPORTS_PER_CONTAINER + 1]:
+            old.unlink(missing_ok=True)
+
+    return path
+
+
+def _summary_report_path(container_name: str) -> Path:
+    """Return a timestamped Markdown summary report path for *container_name*.
+
+    Also prunes older summary reports for the same container, keeping
+    only the last ``MAX_REPORTS_PER_CONTAINER`` files.
+
+    :param container_name: Container name (e.g. ``"ha-sim"``).
+    :return: Absolute path for the new summary file.
+    """
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    path = REPORTS_DIR / f"summary_{container_name}_{ts}.md"
+
+    pattern = f"summary_{container_name}_*.md"
     existing = sorted(REPORTS_DIR.glob(pattern))
     if len(existing) >= MAX_REPORTS_PER_CONTAINER:
         for old in existing[: -MAX_REPORTS_PER_CONTAINER + 1]:
@@ -288,7 +324,24 @@ async def teardown(
     for r in ctx.results:
         print(r)
 
-    print(f"\n  Log report: {report_path}")
+    # =====================================================================
+    # SUMMARY REPORT: Write a Markdown summary alongside the log report
+    # =====================================================================
+    from .report_writer import RunSummary, write_summary_report
+
+    summary = RunSummary(
+        instance=ctx.instance,
+        started_wall=start_time_wall or start_time,
+        elapsed=elapsed,
+        passed=ctx.passed,
+        failed=ctx.failed,
+        recipe_stats=ctx.recipe_stats,
+        results=ctx.results,
+        log_report_path=str(report_path),
+    )
+    summary_path = write_summary_report([summary], reports_dir=REPORTS_DIR)
+    print(f"\n  Log report:     {report_path}")
+    print(f"  Summary report: {summary_path}")
 
     if ctx.failed > 0:
         print(f"\n  {bold(red('*** SOME TESTS FAILED ***'))}")
@@ -327,10 +380,13 @@ async def run(
         print(
             f"\n  ERROR: MQTT broker at {MQTT_BROKER_URL} is not reachable.\n"
             "  Start it via docker compose:\n"
-            "    cd ~/docker_files/ha-sim && docker compose -f docker-compose.mqtt.yml up -d\n"
-            "  Or run a standalone container:\n"
-            "    docker run -d --name ha-sim-mqtt -p 1884:1884 eclipse-mosquitto:latest "
-            "sh -c 'echo \"listener 1884 0.0.0.0\\nallow_anonymous true\" > /tmp/mosquitto.conf && mosquitto -c /tmp/mosquitto.conf'\n"
+            "    cd ~/docker_files/ha-sim && \\\n"
+            "    docker compose -f docker-compose.mqtt.yml up -d\n"
+            "  Or run a standalone mosquitto container:\n"
+            "    docker run -d --name ha-sim-mqtt -p 1884:1884 \\\n"
+            "    eclipse-mosquitto:latest \\\n"
+            "    sh -c \"printf 'listener 1884 0.0.0.0\\nallow_anonymous true\\n' \\\n"
+            '    > /tmp/mosquitto.conf && mosquitto -c /tmp/mosquitto.conf"\n'
             "  Aborting."
         )
         sys.exit(1)


### PR DESCRIPTION
## Summary

Previously only the plain-text log report (errors/warnings) was saved;
the summary (pass/fail counts, per-recipe timing, individual check
results) was only printed to stdout and lost when the terminal closed.

This PR adds a Markdown summary report written alongside the log report
after every run. Markdown serves both human reading (GitHub renders it)
and machine parsing (tables are structured).

### New files
- `tools/ha_sim_test/report_writer.py` — `RunSummary` dataclass and
  `write_summary_report()` function that generates the Markdown report.

### Report contents
- **Run metadata** — timestamp, status (PASS/FAIL), totals, wall time
- **Per-container overview** — pass/fail/time/status table (parallel mode)
- **Per-recipe timing** — recipe, container, pass, fail, duration, title
- **Check results** — every PASS/FAIL line with detail
- **Container errors** — fatal errors per container (if any)
- **Log report references** — paths to the corresponding log reports

### Output paths
- Single-container: `summary_{container}_{ts}.md`
- Parallel: `summary_parallel_{ts}.md`
- Default directory: `tools/ha_sim_test/reports/` (same as log reports)
- Overridable via new `--reports-dir DIR` CLI flag

### Other changes
- `set_reports_dir()` in `runner.py` makes the reports directory
  configurable at runtime (used by the `--reports-dir` flag).
- `InstanceResult` in `parallel.py` gains a `log_report_path` field so
  the parallel summary can cross-reference per-container log reports.
- Fix stale docs path in `HA_SIM_TEST_TOOL.md` (was
  `/tmp/ha_sim_test_log_report.txt`, now reflects the actual
  `tools/ha_sim_test/reports/` directory).
- Fix pre-existing ruff I001/E501 issues inherited from PR 140
  (the `from pathlib import Path` placement and long MQTT hint strings).

#### Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy` passes (pre-commit hook)
- [x] All pre-commit hooks pass
- [x] Smoke-tested `write_summary_report()` with both single-container
      and parallel mock data — Markdown renders correctly
- [ ] CI green on this PR