### PR TITLE
test: add R76 recipe for 0004 zone name polling + mismatch notification

### DIFF
--- a/tools/ha_sim_test/log_monitor.py
+++ b/tools/ha_sim_test/log_monitor.py
@@ -81,6 +81,8 @@ EXPECTED_WARNINGS: list[str] = [
     "bound mismatches between discovery and schema",
     "have no _class but discovery has a suggestion",
     "appear orphaned",
+    # ramses_cc: zone name mismatch (expected in R76 — issue 947)
+    "name mismatches between schema and controller",
     # ramses_cc: bound device not found during early init (FAN not yet active)
     "Bound device",
     "not found for FAN",

--- a/tools/ha_sim_test/recipes/r76_zone_name_0004_polling_issue_947.py
+++ b/tools/ha_sim_test/recipes/r76_zone_name_0004_polling_issue_947.py
@@ -37,10 +37,12 @@ from ..const import CTL
 from ..helpers import (
     call_service,
     get_schema_retry,
+    load_profile_yaml,
     wait_for,
     wait_for_schema_populated,
     ws_send,
 )
+from ..profile import minimal_ctl_zone_yaml
 
 # Zone we'll test — zone 03 in the mixed profile (initial _name='Lounge')
 _ZONE_IDX = "03"
@@ -105,12 +107,33 @@ class R76ZoneName0004PollingIssue947(Recipe):
     async def run(self, ctx: RecipeContext) -> None:
         ctx.log_section("Recipe 76: Zone name 0004 polling regression (issue 947)")
 
-        # The mixed profile from setup has zone 03 with _name='Lounge'.
-        # We use the existing MQTT transport (no profile reload) and
-        # inject a 0004 I packet to change the name to 'Kitchen'.
-        # This proves that 0004 packets are processed and propagate to
-        # the schema and device registry — the same path that the
-        # PollingManager's 0004 RQ would trigger.
+        # Load a minimal profile with _name='Lounge' on zone 03.
+        # We can't rely on the mixed profile from setup because earlier
+        # recipes (e.g. R75) may have changed the schema.  Loading our
+        # own profile ensures a clean, predictable starting state.
+        # Clear any stale _alias from prior recipes (e.g. R09) so the
+        # device registry picks up _name='Lounge' instead.
+        print(
+            f"  Loading minimal profile with _name='{_OLD_NAME}' on zone {_ZONE_IDX}..."
+        )
+        yaml_profile = minimal_ctl_zone_yaml(
+            zone_idx=_ZONE_IDX,
+            zone_name=_OLD_NAME,
+            clear_alias=True,
+        )
+        try:
+            await load_profile_yaml(
+                ctx.token,
+                yaml_profile,
+                speed=0.01,
+                preload_schema=True,
+                reload_ramses=True,
+            )
+            print("  Profile loaded")
+        except RuntimeError as e:
+            print(f"  Profile load failed: {e}")
+        ctx.wait_for_ramses_cc_reload(timeout=20)
+        ctx.refresh_token()
 
         # ── 1. Verify schema has initial _name on zone 03 ────────────
         wait_for_schema_populated(min_keys=2, timeout=10)

--- a/tools/ha_sim_test/recipes/r76_zone_name_0004_polling_issue_947.py
+++ b/tools/ha_sim_test/recipes/r76_zone_name_0004_polling_issue_947.py
@@ -1,0 +1,265 @@
+"""Recipe R76: Zone name 0004 polling regression (issue 947).
+
+Issue 947 root cause 1 — zone names (0004 packets) are missing after
+cache clear because the CTL does not broadcast 0004 spontaneously.
+The legacy DiscoveryService actively polled 0004 (GET_ZONE_NAME) every
+6 hours per zone, but this was removed in ramses_rf commit dba5bf7d
+("remove legacy DiscoveryService") and the replacement PollingManager
+did not include 0004 in its schedule.
+
+The fix (ramses_rf pipeline/polling.py) restores per-zone 0004 polling:
+  - 0004 is added to DEFAULT_POLLING_SCHEDULES for CTL (6-hour interval)
+  - update_device_tasks expands 0004 into per-zone tasks keyed by
+    (device_id, "0004", zone_idx) with the zone_idx in the RQ payload
+
+This recipe verifies end-to-end that:
+  1. A 0004 packet (whether from polling or injection) updates the
+     zone's ``_name`` in the schema
+  2. The device registry name reflects the zone name (not the fallback
+     ``"RAD 01:150000_03"`` form)
+  3. The CTL default polling schedule includes 0004 (unit-level check)
+
+The recipe uses the mixed profile loaded by setup (which already has
+MQTT working) and injects a 0004 I packet to change zone 03's name
+from 'Lounge' to 'Kitchen', proving that 0004 packets are processed
+and propagate to the schema and device registry.
+
+See: https://github.com/ramses-rf/ramses_cc/issues/947
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from ..base import Recipe, RecipeContext
+from ..const import CTL
+from ..helpers import (
+    call_service,
+    get_schema_retry,
+    wait_for,
+    wait_for_schema_populated,
+    ws_send,
+)
+
+# Zone we'll test — zone 03 in the mixed profile (initial _name='Lounge')
+_ZONE_IDX = "03"
+_OLD_NAME = "Lounge"
+_NEW_NAME = "Kitchen"
+
+# Zone device ID is "<ctl_id>_<zone_idx>" e.g. "01:150000_03"
+_ZONE_DEVICE_ID = f"{CTL}_{_ZONE_IDX}"
+
+
+def _encode_zone_name_payload(zone_idx: str, name: str) -> str:
+    """Encode a 0004 zone-name payload.
+
+    Format: zone_idx (1 byte) + 00 (1 byte) + name (ASCII, null-padded
+    to 20 bytes).  Total payload is 22 bytes (44 hex chars).
+
+    The ramses_tx parser expects ``^0[0-9A-F]00([0-9A-F]){40}$`` for
+    I/0004 — zone_idx, then 00, then 40 hex chars of name data.
+
+    :param zone_idx: Zone index as 2-char hex string (e.g. "03").
+    :param name: Zone name as ASCII string (max 20 chars).
+    :returns: Hex payload string.
+    """
+    name_hex = name.encode("ascii").hex().upper()
+    padding = "00" * (20 - len(name))
+    return f"{zone_idx}00{name_hex}{padding}"
+
+
+class R76ZoneName0004PollingIssue947(Recipe):
+    id = "R76"
+    seq = 760
+    title = "Zone name 0004 polling regression (issue 947)"
+
+    async def _get_device_name(self, ctx: RecipeContext) -> str | None:
+        """Get the device registry name for the zone device."""
+        try:
+            resp = await ws_send(ctx.token, {"type": "config/device_registry/list"})
+            devices = resp if isinstance(resp, list) else resp.get("devices", [])
+            for dev in devices:
+                identifiers = dev.get("identifiers", [])
+                for ident in identifiers:
+                    if isinstance(ident, list) and len(ident) == 2:
+                        if ident[0] == "ramses_cc" and ident[1] == _ZONE_DEVICE_ID:
+                            return dev.get("name")
+            return None
+        except Exception as e:
+            print(f"    _get_device_name error: {e}")
+            return None
+
+    async def _wait_for_device_name(
+        self, ctx: RecipeContext, name: str, timeout: int = 30, interval: float = 3
+    ) -> str | None:
+        """Poll for the device name to appear and contain *name*."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            dev_name = await self._get_device_name(ctx)
+            if dev_name is not None and name.lower() in dev_name.lower():
+                return dev_name
+            await asyncio.sleep(interval)
+        return await self._get_device_name(ctx)
+
+    async def run(self, ctx: RecipeContext) -> None:
+        ctx.log_section("Recipe 76: Zone name 0004 polling regression (issue 947)")
+
+        # The mixed profile from setup has zone 03 with _name='Lounge'.
+        # We use the existing MQTT transport (no profile reload) and
+        # inject a 0004 I packet to change the name to 'Kitchen'.
+        # This proves that 0004 packets are processed and propagate to
+        # the schema and device registry — the same path that the
+        # PollingManager's 0004 RQ would trigger.
+
+        # ── 1. Verify schema has initial _name on zone 03 ────────────
+        wait_for_schema_populated(min_keys=2, timeout=10)
+
+        def _schema_has_old_name() -> bool:
+            schema = get_schema_retry()
+            ctl = schema.get(CTL, {})
+            zones = ctl.get("zones", {})
+            zone = zones.get(_ZONE_IDX, {})
+            return isinstance(zone, dict) and zone.get("_name") == _OLD_NAME
+
+        wait_for(
+            _schema_has_old_name,
+            timeout=15,
+            interval=2,
+            msg=f"for schema _name='{_OLD_NAME}' on zone {_ZONE_IDX}",
+            floor=3.0,
+        )
+
+        schema_before = get_schema_retry()
+        ctl_schema = schema_before.get(CTL, {})
+        zones_before = ctl_schema.get("zones", {})
+        zone_03_before = zones_before.get(_ZONE_IDX, {})
+        name_before = (
+            zone_03_before.get("_name") if isinstance(zone_03_before, dict) else None
+        )
+
+        ctx.check(
+            f"schema has _name='{_OLD_NAME}' on zone {_ZONE_IDX} before 0004",
+            name_before == _OLD_NAME,
+            f"_name={name_before!r}",
+        )
+
+        # ── 2. Inject 0004 I packet from CTL with new zone name ──────
+        #    This simulates what the PollingManager's 0004 RQ would
+        #    trigger: the CTL responds with a 0004 RP containing the
+        #    zone name.  We inject it as an I (broadcast) since the
+        #    simulator's inject_message service sends I packets.
+        payload_0004 = _encode_zone_name_payload(_ZONE_IDX, _NEW_NAME)
+        print(
+            f"  Injecting 0004 I from CTL {CTL}"
+            f" (zone {_ZONE_IDX}, name='{_NEW_NAME}')..."
+        )
+        print(f"    payload: {payload_0004}")
+        try:
+            call_service(
+                ctx.token,
+                "ramses_extras",
+                "device_simulator_inject_message",
+                {
+                    "source_id": CTL,
+                    "code": "0004",
+                    "payload": payload_0004,
+                    "verb": "I",
+                },
+            )
+        except RuntimeError as e:
+            print(f"  0004 injection failed: {e}")
+
+        # Trigger sync + force_update to process the 0004 packet
+        ctx.wait(2, "for 0004 packet to be processed")
+        try:
+            call_service(ctx.token, "ramses_cc", "sync_topology")
+        except RuntimeError:
+            pass
+        try:
+            call_service(ctx.token, "ramses_cc", "force_update")
+        except RuntimeError:
+            pass
+
+        # ── 3. Verify the 0004 packet was received and processed ──────
+        #    The 0004 packet updates zone_state.name (runtime state),
+        #    not the schema's _name (which is a config trait pre-loaded
+        #    from the profile).  The device registry name is derived
+        #    from Zone.name() which checks zone_state.name first.
+        #    So we check the device registry name, not the schema _name.
+        ctx.wait(2, "for 0004 packet to propagate to device registry")
+
+        # ── 4. Verify device registry name contains the new zone name ─
+        print(f"  Waiting for device registry name to contain '{_NEW_NAME}'...")
+        device_name = await self._wait_for_device_name(ctx, name=_NEW_NAME, timeout=30)
+
+        ctx.check(
+            f"device registry name contains '{_NEW_NAME}'",
+            device_name is not None and _NEW_NAME.lower() in device_name.lower(),
+            f"device_name={device_name!r}",
+        )
+
+        # ── 4b. Verify name mismatch is detected by discovery ─────────
+        #    The schema still has _name='Lounge' but the controller now
+        #    reports 'Kitchen' via 0004.  The discovery checkpoint should
+        #    detect this mismatch and fire a notification.  We trigger
+        #    sync_topology to force an immediate check.
+        print("  Triggering sync_topology to force name mismatch check...")
+        try:
+            call_service(ctx.token, "ramses_cc", "sync_topology")
+        except RuntimeError:
+            pass
+        ctx.wait(3, "for mismatch check to run")
+
+        # Check the HA log for the name mismatch warning
+        import subprocess
+
+        def _log_has_name_mismatch() -> bool:
+            result = subprocess.run(
+                ["docker", "logs", "--since", "10s", "ha-sim"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            logs = result.stderr or ""
+            return "name mismatch" in logs.lower()
+
+        wait_for(
+            _log_has_name_mismatch,
+            timeout=15,
+            interval=3,
+            msg="for name mismatch warning in HA log",
+            floor=3.0,
+        )
+
+        ctx.check(
+            "name mismatch detected (schema _name != controller 0004 name)",
+            _log_has_name_mismatch(),
+            "expected 'name mismatch' warning in HA log",
+        )
+
+        # ── 5. Verify CTL polling schedule includes 0004 ──────────────
+        #    The PollingManager's DEFAULT_POLLING_SCHEDULES for CTL
+        #    should include 0004.  This is a unit-level check that
+        #    guards against the schedule being accidentally removed.
+        print("  Verifying CTL polling schedule includes 0004...")
+        try:
+            from ramses_rf.const import DevType
+            from ramses_rf.pipeline.polling import DEFAULT_POLLING_SCHEDULES
+
+            ctl_schedule = DEFAULT_POLLING_SCHEDULES.get(DevType.CTL, {})
+            has_0004 = "0004" in ctl_schedule
+            ctx.check(
+                "DEFAULT_POLLING_SCHEDULES[CTL] includes 0004",
+                has_0004,
+                f"CTL schedule codes: {list(ctl_schedule.keys())}",
+            )
+        except ImportError as e:
+            # ramses_rf not installed on the host — skip this check
+            # (the unit test in ramses_rf covers this)
+            print(f"  Skipping polling schedule check (ramses_rf not importable: {e})")
+            ctx.check(
+                "DEFAULT_POLLING_SCHEDULES[CTL] includes 0004 (skipped)",
+                True,
+                "ramses_rf not importable on host — covered by unit test",
+            )

--- a/tools/ha_sim_test/recipes/r76_zone_name_0004_polling_issue_947.py
+++ b/tools/ha_sim_test/recipes/r76_zone_name_0004_polling_issue_947.py
@@ -40,6 +40,7 @@ from ..helpers import (
     load_profile_yaml,
     wait_for,
     wait_for_schema_populated,
+    wait_for_transport_ready,
     ws_send,
 )
 from ..profile import minimal_ctl_zone_yaml
@@ -134,6 +135,11 @@ class R76ZoneName0004PollingIssue947(Recipe):
             print(f"  Profile load failed: {e}")
         ctx.wait_for_ramses_cc_reload(timeout=20)
         ctx.refresh_token()
+
+        # Wait for the MQTT transport to reconnect after the reload.
+        # Without this, injected 0004 packets are silently dropped
+        # ("Transport is closing or has closed").
+        wait_for_transport_ready(timeout=30)
 
         # ── 1. Verify schema has initial _name on zone 03 ────────────
         wait_for_schema_populated(min_keys=2, timeout=10)


### PR DESCRIPTION
## Summary

- Adds R76 recipe (`r76_zone_name_0004_polling_issue_947.py`) that verifies end-to-end:
  1. Schema has `_name='Lounge'` on zone 03 before 0004 injection
  2. A 0004 (zone_name) packet from the CTL updates the device registry name to 'Kitchen'
  3. `sync_topology` triggers the name mismatch check and the warning appears in the HA log
  4. The CTL default polling schedule includes 0004 (unit-level guard, skipped if ramses_rf not importable on host)
- Adds `"name mismatches between schema and controller"` to `EXPECTED_WARNINGS` in `log_monitor.py` — the mismatch warning is the expected behaviour in R76, not an error

Depends on:
- ramses_rf PR #1035 (0004 polling fix)
- ramses_cc PR #950 (name mismatch notification)

Refs: https://github.com/ramses-rf/ramses_cc/issues/947

#### Test plan

- [x] `python -m tools.ha_sim_test R76` — 6/6 checks pass, 0 unexpected errors/warnings
- [x] `ruff check` + `ruff format` + `mypy` — clean